### PR TITLE
Adding - in regex on ElementInspector.js

### DIFF
--- a/leaf-ui/rappid-extensions/ElementInspector.js
+++ b/leaf-ui/rappid-extensions/ElementInspector.js
@@ -320,7 +320,7 @@ var ElementInspector = Backbone.View.extend({
     var text = this.$('.cell-attrs-text').val()
     // Do not allow special characters in names, replace them with spaces.
 
-    text = text.replace(/[^\w\n]/g, ' ');
+    text = text.replace(/[^\w\n-]/g, ' ');
     cell.attr({ '.name': { text: text } });
   },
 


### PR DESCRIPTION
Fixed the bug for issue #67 
I added a - as part of allowed character for naming intention values.
`    text = text.replace(/[^\w\n-]/g, ' ');`
<img width="495" alt="screen shot 2017-09-18 at 12 50 51 pm" src="https://user-images.githubusercontent.com/16656280/30553697-01366e56-9cdd-11e7-8a5a-8222d1837df4.png">

Other special characters continue to be replaced by space
<img width="500" alt="screen shot 2017-09-18 at 12 50 56 pm" src="https://user-images.githubusercontent.com/16656280/30553722-123405ce-9cdd-11e7-9522-a380053b1649.png">

