### PR TITLE
 Model constraint refactor

### DIFF
--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
     <head>

--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -71,7 +71,9 @@
                 </div>
             </div>
 
-            <!--<button id="symbolic-btn" class="blue-btn btn">Model Constraints</button>-->
+            <!-- OLD Button to switch between Constraint view and the Relationship view.
+			The functionality for the Constraint view still exists in the code.
+		<button id="symbolic-btn" class="blue-btn btn">Model Constraints</button>-->
             <button id="analysis-btn" class="green-btn btn">Analysis</button>
             <button id="cycledetect-btn" class="pink-btn btn">Detect Cycles</button>
 

--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -71,7 +71,7 @@
                 </div>
             </div>
 
-            <button id="symbolic-btn" class="blue-btn btn">Model Constraints</button>
+            <!--<button id="symbolic-btn" class="blue-btn btn">Model Constraints</button>-->
             <button id="analysis-btn" class="green-btn btn">Analysis</button>
             <button id="cycledetect-btn" class="pink-btn btn">Detect Cycles</button>
 

--- a/leaf-ui/scripts/main.js
+++ b/leaf-ui/scripts/main.js
@@ -221,6 +221,7 @@ function saveLinks(mode){
 //Switch to analysis mode
 $('#analysis-btn').on('click', function(){
 
+	console.log(linkMode);
 	if (linkMode == "Constraints")
 		$('#symbolic-btn').trigger( "click" );
 
@@ -236,6 +237,7 @@ $('#analysis-btn').on('click', function(){
 
 	$('#analysis-btn').css("display","none");
 	$('#symbolic-btn').css("display","none");
+	$('#cycledetect-btn').css("display","none");
 	$('#dropdown-model').css("display","");
 
 	$('#model-toolbar').css("display","none");
@@ -406,6 +408,7 @@ function switchToModellingMode(useInitState){
 
 	$('#analysis-btn').css("display","");
 	$('#symbolic-btn').css("display","");
+	$('#cycledetect-btn').css("display","");
 	$('#dropdown-model').css("display","none");
 
 	$('#model-toolbar').css("display","");


### PR DESCRIPTION
I removed the blue button and the paper will always stay as "Model Relationship" at this point, unless Analysis button is clicked. I left the codes that were previously used for switching between Model Constraint/Relationships as it is needed for future work.