### PR TITLE
Fixed #46

### DIFF
--- a/leaf-ui/js/object/InputDynamic.js
+++ b/leaf-ui/js/object/InputDynamic.js
@@ -31,12 +31,9 @@ function getDynamics(){
 			initValue = satValueDict[initValue];		 
 		}
 		
-	    if (isNaN(parseInt(funcTypeVal))){
-			funcTypeVal = satValueDict[funcTypeVal];
-		}
 
 	    var io_dynamic;
-	    if(f=="NB"){
+	    if(f == "NB" ){
 	    	io_dynamic = new InputDynamic(elementID, "NB", initValue);
 	    }
 	    else if (f == ""){
@@ -44,6 +41,9 @@ function getDynamics(){
 	    }else if(f == " "){
     		io_dynamic = new InputDynamic(elementID, "NT", initValue);
 	    }else if (f != "UD"){
+		if (isNaN(parseInt(funcTypeVal))){
+		    funcTypeVal = satValueDict[funcTypeVal];
+		}
     		io_dynamic = new InputDynamic(elementID, f, funcTypeVal);		//Passing Dynamic Values
     		// user defined constraints
 	    }else{
@@ -56,9 +56,9 @@ function getDynamics(){
 
 			for (var l = 0; l < funcTypeVal.length; l++){
 				if(l == funcTypeVal.length - 1){
-					line += "\t" + begin[l] + "\t1\t" + funcType[l] + "\t" + String(initValue);
+					line += "\t" + begin[l] + "\t1\t" + funcType[l] + "\t" + satValueDict[funcTypeVal[l]];
 				}else{
-					line += "\t" + begin[l] + "\t" + end[l] + "\t" + funcType[l] + "\t" + String(initValue);
+					line += "\t" + begin[l] + "\t" + end[l] + "\t" + funcType[l] + "\t" + satValueDict[funcTypeVal[l]];
 				}
 			}
 


### PR DESCRIPTION
This fixes #46 (simulate single path doesn't work for user-defined functions).

The source of the issue was that only the initial satisfaction value was taken into account when specifying the 'line' attribute of an intention in the InputDynamic.js file. This was fixed by taking _all_ segments of the user defined function into account. 