### PR TITLE
Bug97 fixed

### DIFF
--- a/leaf-ui/scripts/main.js
+++ b/leaf-ui/scripts/main.js
@@ -816,7 +816,7 @@ function updateValues(c, v, m){
 		//var satvalues = ["denied", "partiallydenied", "partiallysatisfied", "satisfied", "unknown", "none"];
 		cell = graph.allElements[c];
 		value = v;
-		cell.attributes.attrs[".satvalue"].value = v;
+		//cell.attributes.attrs[".satvalue"].value = v;
 		//cell.attr(".satvalue/value", v);
 
 	//Update node based on values saved from graph prior to analysis

--- a/leaf-ui/scripts/main.js
+++ b/leaf-ui/scripts/main.js
@@ -816,7 +816,9 @@ function updateValues(c, v, m){
 		//var satvalues = ["denied", "partiallydenied", "partiallysatisfied", "satisfied", "unknown", "none"];
 		cell = graph.allElements[c];
 		value = v;
+		// Potential fix to Issue #97 was to revove the next line. (Jan 2018)
 		//cell.attributes.attrs[".satvalue"].value = v;
+		// The following line was here originally commented out.
 		//cell.attr(".satvalue/value", v);
 
 	//Update node based on values saved from graph prior to analysis


### PR DESCRIPTION
Proposed fix for bug 97. Previously, whenever SinglePath is executed, the Initial Satisfaction Values became empty and Function Type values would disappear when you click on a model.
I commented line 819 on release-one branch and it seems to fix it.
<img width="1132" alt="screen shot 2018-01-02 at 10 41 44 am" src="https://user-images.githubusercontent.com/16656280/34489296-c7d52560-efa9-11e7-8058-8051ad4abe9c.png">

