### PR TITLE
Fix bug where graph fails to load from cookies issue #143

### DIFF
--- a/leaf-ui/scripts/main.js
+++ b/leaf-ui/scripts/main.js
@@ -142,8 +142,8 @@ if (document.cookie){
 
 	//Loop through the cookies to find the one representing the graph, if it exists
 	for (var i = 0; i < cookies.length; i++){
-		if (cookies[i].indexOf("graph=") >= 0){
-			prevgraph = cookies[i].substr(6);
+		if (cookies[i].indexOf("graph=") !== -1){ // If substring exists
+			prevgraph = cookies[i].substr(cookies[i].indexOf("graph=" + 6)); // Get the substring after graph=
 			break;
 		}
 	}

--- a/leaf-ui/scripts/main.js
+++ b/leaf-ui/scripts/main.js
@@ -147,10 +147,16 @@ if (document.cookie){
 			break;
 		}
 	}
-	console.log(graph.fromJSON(JSON.parse(prevgraph)));
+
 	if (prevgraph){
-		graph.fromJSON(JSON.parse(prevgraph));
+		try {
+			graph.fromJSON(JSON.parse(prevgraph));
+		} catch (e) {
+			// this should never happen, but just in case
+			alert('Previously stored cookies contains invalid JSON data. Please clear your cookies.');
+		}
 	}
+
 }
 
 


### PR DESCRIPTION
… unresponsive

This is for issue #143.

The reason why the webpage was sometimes unresponsive for the first time was that there was an error when the webpage tried to load the graph from the cookies. 

JSON.parse(prevgraph) would throw an error if prevgraph did not contain a proper JSON object in a string format. The cause of the error was simply because a console.log statement called JSON.parse(prevgraph) before checking if prevgraph is a valid JSON in string format. 
 
