### PR TITLE
Update ElementInspector.js

### DIFF
--- a/leaf-ui/rappid-extensions/ElementInspector.js
+++ b/leaf-ui/rappid-extensions/ElementInspector.js
@@ -212,6 +212,10 @@ var ElementInspector = Backbone.View.extend({
         } else {
             this.updateHTML(null);
         }
+        
+        if(functionType == 'I' || functionType == 'D' || functionType == 'MN' || functionType == 'MP'){
+            this.displayFunctionSatValue(null);
+        }
 
         this.updateCell();
 


### PR DESCRIPTION
Although I have no idea why it happens, through trial and error, I identified that the markedValue table would not update after the render function is called (basically whenever we click back onto the "cell"). This is even worse as the render actually resets the properties of the cell and then re-updates the cell depending on the input data (which is doubly weird as everything else seems to re-update fine except for the markedValue table). (Note: It would not surprise me if someone else also fails to re-update). Again, I have no idea why, but when I remind the render function to update the markedValue table if the function is either I,D, MP or MN, it seems to fix the problem. But the good thing is that it now works (and I understand why my edit would impact the code and make it work but not why it didn't work in the first place). 