### PR TITLE
bug fix - Show loaded results on click 

### DIFF
--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -25,10 +25,10 @@ function displayAnalysis(analysisResults){
     currentAnalysis.type = "Single Path";
 
     // Save data for get possible next states
-    savedAnalysisData.singlePathResult.assignedEpoch = analysisResults.assignedEpoch;
-    savedAnalysisData.singlePathResult.finalValueTimePoints = analysisResults.finalValueTimePoints;
     savedAnalysisData.singlePathResult = analysisResults;
-    console.log("savedAnalysisData");
+    // savedAnalysisData.singlePathResult.assignedEpoch = analysisResults.assignedEpoch;
+    // savedAnalysisData.singlePathResult.finalValueTimePoints = analysisResults.finalValueTimePoints;
+    console.log(savedAnalysisData);
 
     // Check if slider has already been initialized
     if (sliderObject.sliderElement.hasOwnProperty('noUiSlider')) {
@@ -289,14 +289,8 @@ function loadAnalysis(){
         updateResults();
         console.log("analysis request:")
         console.log(analysisRequest);
-        // Refresh the sidebar to include the config vars
-        refreshAnalysisBar();
     }
-    // TODO: figure out how to set it to the element of the map that will populate on top
-    currAnalysisConfig = analysisMap.get("Configuration1");
-    analysisRequest = currAnalysisConfig.analysisRequest;
-    console.log("analysis request:")
-    console.log(analysisRequest);
+    // Refresh the sidebar to include the config vars
     refreshAnalysisBar();
 }
 

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -25,22 +25,13 @@ function displayAnalysis(analysisResults){
     currentAnalysis.type = "Single Path";
 
     // Save data for get possible next states
+    // TODO double check this still works
     savedAnalysisData.singlePathResult = analysisResults;
-    // savedAnalysisData.singlePathResult.assignedEpoch = analysisResults.assignedEpoch;
-    // savedAnalysisData.singlePathResult.finalValueTimePoints = analysisResults.finalValueTimePoints;
-    console.log(savedAnalysisData);
 
     // Check if slider has already been initialized
     if (sliderObject.sliderElement.hasOwnProperty('noUiSlider')) {
         sliderObject.sliderElement.noUiSlider.destroy();
     }
-
-    // This might be unnecessary
-    // ElementList = analysisResults.elementList;
-
-    // Update history log
-    // updateHistory(currentAnalysis);
-
     createSlider(currentAnalysis, false);
 }
 
@@ -261,15 +252,12 @@ function addFirstAnalysisConfig(){
     // TODO: Find better way to preserve original default from model
     // Currently necessary for User Assignments List preservation
     defaultUAL = currAnalysisConfig.userAssignmentsList;
-    console.log(analysisRequest.userAssignmentsList);
     var buttonLabel = currAnalysisConfig.id + "-button";
     var label = currAnalysisConfig.id + "-dropdown";
     $("#analysis-sidebar").append(
         '<button class="log-elements" id="'+currAnalysisConfig.id+'" style="padding: 12px; font-size: 16px; border: none; outline: none; background-color:#A9A9A9">' + currAnalysisConfig.id + '</button><div style="position:absolute; display:inline-block"><button class="dropdown" id= "'+buttonLabel+'" style="padding: 12px; font-size: 16px; height: 42px; border: none; outline: none;"><i class="fa fa-caret-down fa-2x" style="cursor:pointer;"></i></button>'
         + '</div><div class = "dropdown-container" id="'+label+'"></div>'
       );
-
-    console.log(analysisMap)
 }
 
 /**
@@ -287,7 +275,6 @@ function loadAnalysis(){
         addAnalysisConfig();
         // Add the results (if any) to the sidebar
         updateResults();
-        console.log("analysis request:")
         console.log(analysisRequest);
     }
     // Refresh the sidebar to include the config vars
@@ -327,7 +314,6 @@ function addNewAnalysisConfig(){
  * Adds an analysis configuration to the UI (config sidebar)
  */
 function addAnalysisConfig() {
-    console.log("add a new config to the UI");
     $(".log-elements").css("background-color", "");
     $(".result-elements").css("background-color", "");
     var buttonLabel = currAnalysisConfig.id + "-button";
@@ -342,7 +328,6 @@ function addAnalysisConfig() {
  * Adds result to UI menu
  */
 function updateResults(){
-    console.log("add results to the UI");
     $(".result-elements").css("background-color", "");
     var label = currAnalysisConfig.id + "-dropdown";
     // clear all results from dropdown (prevents duplication)
@@ -361,7 +346,6 @@ function updateResults(){
 }
 
 function refreshAnalysisBar(){
-    console.log("refresh the analysis sidebar");
     $('#conflict-level').val(analysisRequest.conflictLevel);
     $('#num-rel-time').val(analysisRequest.numRelTime);
 }

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -1368,8 +1368,11 @@ function checkForMultipleNB(node) {
  * TODO: fix bug - creates a duplicate config if switching from model to analysis multiple times
  */
 function loadAnalysisConfig(){
+    // Refresh the analysis sidebar to reflect current analysis request values
+    refreshAnalysisBar();
     // if there are no configs in the map
     if(analysisMap.size == 0){
+        // Add a new, empty config to the map
         addFirstAnalysisConfig();
     }
 }


### PR DESCRIPTION
Two bugs one stone: allow users to view results in the UI by clicking on them, and fix a new bug I found - the analysis sidebar needs to be refreshed when loading data from a json, so as to display the info in the AnalysisRequest instead of the default conflict prevention level etc. when switching to analysis mode for the first time.  