### PR TITLE
Adjust UI for results/configs

### DIFF
--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -438,15 +438,13 @@ $('#analysis-sidebar').on("click", ".result-elements", function(e){
     $('#modelingSlider').css("display", "none");
     $('#analysisSlider').css("display", "");
 
-    // show current EVO
+    // TODO: show current EVO
+    // perhaps it would be more useful to refresh EVO every time displayAnalysis() is called?
+    // since it switches to modeling mode every time hideAnalysis() is called
+    EVO.refresh();
     // currAnalysisResults.colorVis.colorIntentionsAnalysis();
-
-    // TODO: does this make sense?
     //document.getElementById("colorReset").value = EVO.sliderOption;
     //document.getElementById("colorResetAnalysis").value = EVO.sliderOption;
-    EVO.refresh();
-
-    // chance displayAnalysis() to refresh EVO?
 });
 
 /**

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -77,6 +77,28 @@ function createSlider(currentAnalysis, isSwitch) {
     adjustSliderWidth(sliderMax);
 }
 
+/**
+ * Reset display to default, before result is displayed
+ */
+function hideAnalysis() {
+    removeSlider();
+    refreshAnalysisBar();
+    // show modeling mode EVO slider
+    $('#modelingSlider').css("display", ""); // ask Kate and Megan
+    $('#analysisSlider').css("display", "none");
+}
+
+/**
+ * Removes the slider from the UI
+ */
+function removeSlider() {
+    // if there's a slider, remove it
+    if (sliderObject.sliderElement.hasOwnProperty('noUiSlider')) {
+        sliderObject.sliderElement.noUiSlider.destroy();
+    }
+    $('#sliderValue').text("");
+}
+
 /*
  * Creates and displays new slider after the user clicks a different
  * analysis from the history log. This function is called when
@@ -306,8 +328,9 @@ function addNewAnalysisConfig(){
     currAnalysisConfig = newConfig;
     analysisRequest = currAnalysisConfig.getAnalysisRequest();
 
-    // Reset analysis sidebar to default
-    refreshAnalysisBar();
+    // Reset analysis view to default
+    hideAnalysis();
+    // refreshAnalysisBar();
     // Add the config to the sidebar
     addAnalysisConfig();
 }
@@ -363,7 +386,10 @@ $('#analysis-sidebar').on("click", ".log-elements", function(e){
 
     currAnalysisConfig = analysisMap.get(txt);
     analysisRequest = currAnalysisConfig.getAnalysisRequest();
-    refreshAnalysisBar();
+    // restore default analysis view
+    hideAnalysis();
+    //refreshAnalysisBar(); // reset UI
+    // removeSlider();
     console.log(analysisRequest.userAssignmentsList);
 
     $(".log-elements").css("background-color", "");
@@ -395,15 +421,18 @@ $('#analysis-sidebar').on("click", ".result-elements", function(e){
     // Grab Config and result information
     var configId = e.currentTarget.parentElement.id.split("-")[0];
     var resultIndex = $(e.target).text().split(" ")[1];
-    var currAnalysisConfig = analysisMap.get(configId)
+    var currAnalysisConfig = analysisMap.get(configId);
     var currAnalysisResults = currAnalysisConfig.analysisResults[resultIndex-1];
     analysisRequest = currAnalysisConfig.getAnalysisRequest();
 
     // Update UI accordingly
     $(e.target).css("background-color", "#A9A9A9");
-    $("#"+configId).css("background-color","#A9A9A9")
-    refreshAnalysisBar()
-    displayAnalysis(currAnalysisResults)
+    $("#"+configId).css("background-color","#A9A9A9");
+    refreshAnalysisBar();
+    displayAnalysis(currAnalysisResults);
+    // show EVO analysis slider
+    $('#modelingSlider').css("display", "none"); // ask Kate and Megan
+    $('#analysisSlider').css("display", "");
 });
 
 /**

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -84,10 +84,11 @@ function hideAnalysis() {
     removeSlider();
     refreshAnalysisBar();
     revertNodeValuesToInitial();
+    // TODO: make sure EVO goes back to analysis mode properly when clicking on result
     EVO.switchToModelingMode();
     analysisResult.colorVis = [];
     // show modeling mode EVO slider
-    $('#modelingSlider').css("display", ""); // ask Kate and Megan
+    $('#modelingSlider').css("display", "");
     $('#analysisSlider').css("display", "none");
 }
 
@@ -333,7 +334,7 @@ function addNewAnalysisConfig(){
 
     // Reset analysis view to default
     hideAnalysis();
-    // refreshAnalysisBar();
+
     // Add the config to the sidebar
     addAnalysisConfig();
 }
@@ -389,10 +390,10 @@ $('#analysis-sidebar').on("click", ".log-elements", function(e){
 
     currAnalysisConfig = analysisMap.get(txt);
     analysisRequest = currAnalysisConfig.getAnalysisRequest();
+    
     // restore default analysis view
     hideAnalysis();
-    //refreshAnalysisBar(); // reset UI
-    // removeSlider();
+
     console.log(analysisRequest.userAssignmentsList);
 
     $(".log-elements").css("background-color", "");

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -83,6 +83,9 @@ function createSlider(currentAnalysis, isSwitch) {
 function hideAnalysis() {
     removeSlider();
     refreshAnalysisBar();
+    revertNodeValuesToInitial();
+    EVO.switchToModelingMode();
+    analysisResult.colorVis = [];
     // show modeling mode EVO slider
     $('#modelingSlider').css("display", ""); // ask Kate and Megan
     $('#analysisSlider').css("display", "none");

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -86,7 +86,7 @@ function hideAnalysis() {
     revertNodeValuesToInitial();
     // TODO: make sure EVO goes back to analysis mode properly when clicking on result
     EVO.switchToModelingMode();
-    analysisResult.colorVis = [];
+    //analysisResult.colorVis = [];
     // show modeling mode EVO slider
     $('#modelingSlider').css("display", "");
     $('#analysisSlider').css("display", "none");
@@ -435,8 +435,18 @@ $('#analysis-sidebar').on("click", ".result-elements", function(e){
     refreshAnalysisBar();
     displayAnalysis(currAnalysisResults);
     // show EVO analysis slider
-    $('#modelingSlider').css("display", "none"); // ask Kate and Megan
+    $('#modelingSlider').css("display", "none");
     $('#analysisSlider').css("display", "");
+
+    // show current EVO
+    // currAnalysisResults.colorVis.colorIntentionsAnalysis();
+
+    // TODO: does this make sense?
+    //document.getElementById("colorReset").value = EVO.sliderOption;
+    //document.getElementById("colorResetAnalysis").value = EVO.sliderOption;
+    EVO.refresh();
+
+    // chance displayAnalysis() to refresh EVO?
 });
 
 /**

--- a/leaf-ui/js/object/Class.js
+++ b/leaf-ui/js/object/Class.js
@@ -799,8 +799,9 @@ class EVO {
      * Switch back to modeling slider, if EVO is on the visualization returns to filling by initial state.
      */
      static switchToModelingMode() {
-            $('#modelingSlider').css("display", "");
-            $('#analysisSlider').css("display", "none");
+        $('#modelingSlider').css("display", "");
+        $('#analysisSlider').css("display", "none");
+        // if EVO is on in analysis mode, keep it on
         if(EVO.sliderOption > 0) {
             EVO.sliderOption = '1';
         }

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -489,7 +489,6 @@ function switchToModellingMode() {
     analysisResult.isPathSim = false; //reset isPathSim for color visualization slider
 	analysisRequest.previousAnalysis = null;
 	clearInspector();
-    removeSlider();
 
 	// Reset to initial graph prior to analysis
 	revertNodeValuesToInitial();
@@ -512,8 +511,7 @@ function switchToModellingMode() {
     EVO.switchToModelingMode();
     analysisResult.colorVis = [];
 
-
-	$('#sliderValue').text("");
+    removeSlider();
 
 	// Reinstantiate link settings
 	$('.link-tools .tool-remove').css("display","");

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -446,6 +446,12 @@ $('#model-cur-btn').on('click', function() {
  * satisfaction value and colours all text to black
  */
 function revertNodeValuesToInitial() {
+    // reset values
+    for (var i = 0; i < graph.elementsBeforeAnalysis.length; i++) {
+		var value = graph.elementsBeforeAnalysis[i]
+		updateNodeValues(i, value, "toInitModel");
+	}
+
 	var elements = graph.getElements();
 	var curr;
 	for (var i = 0; i < elements.length; i++) {
@@ -482,12 +488,6 @@ function switchToModellingMode() {
     analysisResult.isPathSim = false; //reset isPathSim for color visualization slider
 	analysisRequest.previousAnalysis = null;
 	clearInspector();
-
-	// Reset to initial graph prior to analysis
-	for (var i = 0; i < graph.elementsBeforeAnalysis.length; i++) {
-		var value = graph.elementsBeforeAnalysis[i]
-		updateNodeValues(i, value, "toInitModel");
-	}
 
 	// Reset to initial graph prior to analysis
 	revertNodeValuesToInitial();

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -489,6 +489,7 @@ function switchToModellingMode() {
     analysisResult.isPathSim = false; //reset isPathSim for color visualization slider
 	analysisRequest.previousAnalysis = null;
 	clearInspector();
+    removeSlider();
 
 	// Reset to initial graph prior to analysis
 	revertNodeValuesToInitial();

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -446,6 +446,7 @@ $('#model-cur-btn').on('click', function() {
  * satisfaction value and colours all text to black
  */
 function revertNodeValuesToInitial() {
+    // TODO: get satisfaction text to disappear
     // reset values
     for (var i = 0; i < graph.elementsBeforeAnalysis.length; i++) {
 		var value = graph.elementsBeforeAnalysis[i]


### PR DESCRIPTION
When a user switches from modeling mode to analysis mode, features such as the slider don't appear until after a result is calculated. This branch aims to restore that UI look when a user clicks on a configuration, and then switch back to viewing results when a result is clicked.

This branch creates proper behavior for the slider, the EVO slider, and the analysis sidebar. Switching EVO views is left as a future issue for @kmbspencer and @mvarnum (related to #280). A related bug where satisfaction values don't disappear when switching to modeling mode has been found to be related to EVO and is left to that issue as well.

Resolves issues #263 and #274.