### PR TITLE
Fix load-clear-reload bug

### DIFF
--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -9,6 +9,9 @@ reader = new FileReader();
 // Whenever the input is changed, read the file.
 loader.onchange = function() {
 	reader.readAsText(loader.files.item(0));
+	// Resets loader value so that the onchange event will still be triggered 
+	// if the same file is cleared and then loaded again
+	loader.value = "";
 };
 
 // When read is performed, if successful, load that file.


### PR DESCRIPTION
Fixes #300 by resetting the loader input value after reading in a file. The input was not being reset at any point so if you loaded the same file again after clearing it the onchange event would not be triggered. To reduce code duplication I reset the value inside the loader after it was read in - I think if we wanted to move it to the actual clear functions we could do that as well but potentially after restructuring the clear functions to avoid that same duplication. This should be an easy fix in the meantime.

**Note:** @krhablutzel this branch can't really be fully tested/merged until after your Pull Request #299 which fixes the analysisRequest issue. I just manually fixed (and then deleted the fix since you did it in your branch) in this branch to check.