### PR TITLE
Fix Documentation link to download

### DIFF
--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -67,7 +67,7 @@
             <div class="dropdown">
               <div class="btn">Help</div>
               <div class="dropdown-toolbar">
-                <a onclick="window.open('documentation.pdf'); return false;">Documentation</a>
+                <a href="/documentation.pdf" download='documentation.pdf'">Download Documentation</a>
                 <a onclick="window.open('legend.html', 'newwindow', 'width=300, height=250'); return false;">
                 Legend</a>
                 <a onclick="window.open('evo.html', 'newwindow', 'width=500, height=400'); return false;">


### PR DESCRIPTION
This should make documentation available across browsers. Closes #234.