### PR TITLE
Scroll bar

### DIFF
--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -172,7 +172,7 @@
             <div class="addConfig" style="display:inline">
                 <i class="fa fa-plus" id="addIntent" style="font-size:30px; float:right;  margin-bottom:5px; margin-right:20px;"></i>
             </div></h3>
-            <div id="configurations" class="left-panel" style="margin-top:20px; overflow-y:auto; height:69%"></div>
+            <div id="configurations" class="left-panel" style="margin-top:20px; overflow-y:auto; height:69%; box-shadow: none;"></div>
         </div>
 
         <div id="paper">

--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -166,14 +166,13 @@
 		      <button id="symbolic-btn" class="blue-btn btn">Model Constraints</button>-->
             <button id="analysis-btn" class="green-btn btn" style="border-radius:none;">Analysis</button>
         </div>
-        
-
+         
         <div id="stencil" class="left-panel"><label>Stencil</label></div>
         <div id="analysis-sidebar" class="left-panel"><h3 style="text-align:left; color:#181b1fe3; margin-bottom:5px; margin-left: 10px;">Analysis
             <div class="addConfig" style="display:inline">
                 <i class="fa fa-plus" id="addIntent" style="font-size:30px; float:right;  margin-bottom:5px; margin-right:20px;"></i>
             </div></h3>
-            <div id="configurations" class="left-panel" style="margin-top:20px"></div>
+            <div id="configurations" class="left-panel" style="margin-top:20px; overflow-y:auto; height:69%"></div>
         </div>
 
         <div id="paper">

--- a/leaf-ui/js/initializeElements.js
+++ b/leaf-ui/js/initializeElements.js
@@ -330,7 +330,7 @@ var goal = new joint.shapes.basic.Goal({ position: {x: 50, y: 20} });
 var task = new joint.shapes.basic.Task({ position: {x: 50, y: 100} });
 var sgoal = new joint.shapes.basic.Softgoal({ position: {x: 50, y: 170} });
 var res = new joint.shapes.basic.Resource({ position: {x: 50, y: 250} });
-var act = new joint.shapes.basic.Actor({ position: {x: 40, y: 400} });
+var act = new joint.shapes.basic.Actor({ position: {x: 40, y: 355} });
 
 stencil.load([goal, task, sgoal, res, act]);
 


### PR DESCRIPTION
Here I reduced the size of the configuration div and added a scroll bar to make it easier to access configs that were previously covered by the watermark. I also moved the actor element up in modelling view to minimize the risk of the watermark overlapping as well. However, these are both temporary fixes. A larger CSS fix needs to be done to separate the watermark from the left panel div and figure out how to best do that. This may be slightly more difficult in modelling mode, as well just in terms of consistency between two modes and the way the joint.js theme and css works for the node element panel. Pushing that off to our aesthetic UI/CSS overhaul with @krhablutzel (thanks Kathleen!), but this patch fix should at least lower the chances of inaccessible configs in the meantime. This was a super fast and dirty fix so any improvements/suggestions/other paths for this are more than welcome!