### PR TITLE
Reset graph UI when clearing results/configs

### DIFF
--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -82,7 +82,6 @@ function createSlider(currentAnalysis, isSwitch) {
  * Reset display to default, before result is displayed
  */
 function hideAnalysis() {
-    removeSlider();
     refreshAnalysisUI();
     revertNodeValuesToInitial();
     // TODO: make sure EVO goes back to analysis mode properly when clicking on result
@@ -344,6 +343,8 @@ function updateResults(){
     }
     // remove all results from all config divs
     $('.result-elements').remove();
+    // reset graph to initial values
+    revertNodeValuesToInitial();
 }
 
 /**

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -495,6 +495,8 @@ function revertNodeValuesToInitial() {
         //curr.attr({text: {fill: 'black'}});
         curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal','font-size': 10}});
 	}
+    // Remove slider
+    removeSlider();
 }
 
 /**
@@ -532,8 +534,6 @@ function switchToModellingMode() {
     $('.analysis-clears').css("display", "none");
 
     analysisResult.colorVis = [];
-
-    removeSlider();
 
 	// Reinstantiate link settings
 	$('.link-tools .tool-remove').css("display","");
@@ -656,6 +656,8 @@ $('#btn-clear-analysis').on('click', function() {
     analysisMap.clear();
 	// add back first default analysis config
     addFirstAnalysisConfig();
+    // reset graph to initial values
+    revertNodeValuesToInitial();
 });
 
 $('#btn-clear-results').on('click', function() {


### PR DESCRIPTION
Fixes #321. I did this by moving the removeSlider() function into the revertNodeValuesToInitial() function, and calling it inside the functiosn triggered by clear results and/or configs. I looked at use cases for revertNodeValuesToInitial() and noticed that it was always called in tandem with removeSlider() so thought it would be more efficient to move it directly inside that function.