### PR TITLE
Resolves bugs with interaction of actors and intentions

### DIFF
--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -59,7 +59,6 @@ reader.onload = function() {
 		        initSat = (initSat !== ' ' && initSat !== '')  ?  oldSatValToBinary[initSat] : '0000';
 			    var intentionEval = new UserEvaluation(intention.nodeID, '0', initSat);
 			    analysisRequest.userAssignmentsList.push(intentionEval);
-				console.log(analysisRequest.userAssignmentsList);
 		    
 		        // make the T upside down
 		        var satValText = cells[i].attrs['.satvalue'].text;

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -51,7 +51,7 @@ reader.onload = function() {
 		    	cells[i]["nodeID"]  = intention.nodeID;
 
 		    	if (actorID !== '-') {
-		    		model.getActorByID(actorID).intentionIDs.push(intention.nodeID);
+		    		model.getActorByID(actorID).addIntentionID(intention.nodeID);
 		    	} 
 
 		        // create intention evaluation
@@ -59,6 +59,7 @@ reader.onload = function() {
 		        initSat = (initSat !== ' ' && initSat !== '')  ?  oldSatValToBinary[initSat] : '0000';
 			    var intentionEval = new UserEvaluation(intention.nodeID, '0', initSat);
 			    analysisRequest.userAssignmentsList.push(intentionEval);
+				console.log(analysisRequest.userAssignmentsList);
 		    
 		        // make the T upside down
 		        var satValText = cells[i].attrs['.satvalue'].text;

--- a/leaf-ui/js/object/Class.js
+++ b/leaf-ui/js/object/Class.js
@@ -1837,14 +1837,11 @@ class AnalysisRequest {
     }
 
     /**
-     * Removes all UserEvaluation objects in
-     * userAssignmentsList, with an intentionID equal to
-     * nodeID
+     * Removes the UserEvaluation object in
+     * userAssignmentsList that corresponds with nodeID
      *
      * @param {String}
      */
-
-
     removeIntention(nodeID) {
         for (var i = 0; i < this.userAssignmentsList.length; i++) {
             if (this.userAssignmentsList[i].intentionID == nodeID) {

--- a/leaf-ui/js/object/Class.js
+++ b/leaf-ui/js/object/Class.js
@@ -293,25 +293,29 @@ class Actor {
 
     /**
      * Removes intention ID nodeID from the
-     * intentionIDs array
+     * actor's intentionIDs array
      *
      * @param{String} nodeID
      */
-    removeIntentionID(nodeID,  userAssignmentsList) {
-        for (var i = 0; i < this.intentionIDs.length; i++) {
-            if (this.intentionIDs[i] == nodeID) {
-                this.intentionIDs.splice(i, 1);
-                return ;
-            }
-        }
-        while (i < userAssignmentsList.length) {
-            if (userAssignmentsList[i].intentionID == nodeID) {
-                userAssignmentsList.splice(i, 1);
-            } else {
-                i++;
-            }
-        }
+    removeIntentionID(nodeID) {
+        // remove node from intentionIDs list
+        var ind = this.intentionIDs.indexOf(nodeID);
+        this.intentionIDs.splice(ind, 1);
+    }
 
+    /**
+     * Adds intention ID nodeID to the
+     * intentionIDs array if not a duplicate
+     *
+     * @param{String} nodeID
+     */
+    addIntentionID(nodeID) {
+        // add if not in list already
+        if (!this.intentionIDs.includes(nodeID)) {
+            this.intentionIDs.push(nodeID);
+            // keep list sorted
+            this.intentionIDs.sort();
+        }
     }
 }
 Actor.numOfCreatedInstances = 0;
@@ -1842,13 +1846,10 @@ class AnalysisRequest {
 
 
     removeIntention(nodeID) {
-        var i = 0;
-
-        while (i < this.userAssignmentsList.length) {
+        for (var i = 0; i < this.userAssignmentsList.length; i++) {
             if (this.userAssignmentsList[i].intentionID == nodeID) {
                 this.userAssignmentsList.splice(i, 1);
-            } else {
-                i++;
+                break;
             }
         }
     }

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -1214,18 +1214,17 @@ graph.on('change:size', function(cell, size) {
 graph.on('remove', function(cell) {
     //TODO: What I have changed
     if(cell.isLink() && !(cell.prop("link-type") == 'NBT' || cell.prop("link-type") == 'NBD')){
-        //To remove link
+        // To remove link
         var link = cell;
         clearInspector();
         model.removeLink(link.linkID);
     }
 
     else if((!cell.isLink()) && (!(cell["attributes"]["type"]=="basic.Actor"))){
-        //To remove intentions
+        // To remove intentions
         clearInspector();
         var userIntention = model.getIntentionByID(cell.attributes.nodeID);
         // remove this intention from the model
-        //model.removeIntention(userIntention.nodeID);
         model.removedynamicFunction(userIntention.nodeID);
         model.removeIntentionLinks(userIntention.nodeID);
         // remove all intention evaluations associated with this intention
@@ -1234,16 +1233,12 @@ graph.on('remove', function(cell) {
         // from the actor
         if (userIntention.nodeActorID !== '-') {
             var actor = model.getActorByID(userIntention.nodeActorID);
-            //console.log(model);
             actor.removeIntentionID(userIntention.nodeID);
-            console.log('removed node graph.on line 1251');
-            console.log(actor.intentionIDs);
-            //console.log(model);
         }
         model.removeIntention(userIntention.nodeID);
     }
     else if((!cell.isLink()) && (cell["attributes"]["type"]=="basic.Actor")){
-        //To remove actor
+        // To remove actor
         model.removeActor(cell['attributes']['nodeID']);
 
 

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -694,6 +694,7 @@ function createIntention(cell) {
         if (userIntention.nodeActorID !== '-') {
         	var actor = model.getActorByID(userIntention.nodeActorID);
         	actor.removeIntentionID(userIntention.nodeID, analysisRequest.userAssignmentsList);
+            console.log('removed node cell.on line 697');
         }
 
     });
@@ -1044,9 +1045,16 @@ paper.on('cell:pointerdown', function(cellView, evt, x, y) {
 		cell.reparent();
 	}
 
-	// Unembed cell so you can move it out of actor
+	// Unembed intention so you can move it out of actor
 	if (cell.get('parent') && !(cell instanceof joint.dia.Link)) {
 		graph.getCell(cell.get('parent')).unembed(cell);
+
+        // remove nodeID from actor intentionIDs list
+        var userIntention = model.getIntentionByID(cell.attributes.nodeID);
+        if (userIntention.nodeActorID !== '-') {
+            var actor = model.getActorByID(userIntention.nodeActorID);
+            actor.removeIntentionID(userIntention.nodeID, analysisRequest.userAssignmentsList);
+        }
 	}
 });
 
@@ -1247,7 +1255,10 @@ graph.on('remove', function(cell) {
         // from the actor
         if (userIntention.nodeActorID !== '-') {
             var actor = model.getActorByID(userIntention.nodeActorID);
+            console.log(model);
             actor.removeIntentionID(userIntention.nodeID,analysisRequest.userAssignmentsList);
+            console.log('removed node graph.on line 1251');
+            console.log(model);
         }
         model.removeIntention(userIntention.nodeID);
     }

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -1179,9 +1179,11 @@ function embedBasicActor(cell) {
     var ActorsBelow = paper.findViewsFromPoint(cell.getBBox().center());
 
     // intention always returns with ActorsBelow
+    // so always at least one element in list
     if (ActorsBelow.length > 1) {
         // if actors in addition to intention
         for (var i = 0; i < ActorsBelow.length; i++) {
+            // embed intention in each actor
             var actorCell = ActorsBelow[i].model;
             if (actorCell instanceof joint.shapes.basic.Actor) {
                 actorCell.embed(cell);

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -682,7 +682,7 @@ function createIntention(cell) {
     // when the intention is removed, remove the intention from the global
     // model variable as well
     cell.on("remove", function () {
-        console.log("removed");
+        console.log("removed 685");
     	clearInspector();
     	var userIntention = model.getIntentionByID(cell.attributes.nodeID);
     	// remove this intention from the model
@@ -703,7 +703,7 @@ function createIntention(cell) {
     /**
      * Testing drag/drop behavior
      */
-    cell.on('dragstart', function() {
+    cell.on("dragStart", function(evt, x, y) {
 
         console.log("dragging");
 
@@ -721,13 +721,18 @@ function createIntention(cell) {
     });
 
     // drop cell in actor
-    cell.on('dragend', function() {
+    cell.on("dragEnd", function(evt, x, y) {
         // not link
         if (!(cell instanceof joint.dia.Link)){
             // embed in actor
             console.log("embedding in actor");
             embedBasicActor(cell);
         }
+    });
+
+    // testing which event listeners work
+    cell.on("pointerdown", function() {
+        console.log("line 735");
     });
 
 }
@@ -1075,6 +1080,30 @@ paper.on('cell:pointerdown', function(cellView, evt, x, y) {
 	if (cell instanceof joint.dia.Link){
 		cell.reparent();
 	}
+});
+
+paper.on('element:mouseover', function(cellView, evt, x, y) {
+	var cell = cellView.model;
+	console.log('mouseover');
+    console.log(cell);
+});
+
+paper.on('element:dragEnd', function(cellView, evt, x, y) {
+	var cell = cellView.model;
+	console.log('dragEnd');
+    console.log(cell);
+});
+
+paper.on('element:dragStart', function(cellView, evt, x, y) {
+	var cell = cellView.model;
+	console.log('dragStart');
+    console.log(cell);
+});
+
+paper.on('element:dragEnd', function(cellView, evt, x, y) {
+	var cell = cellView.model;
+	console.log('dragEnd');
+    console.log(cell);
 });
 
 // Unhighlight everything when blank is being clicked

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -674,6 +674,9 @@ function createIntention(cell) {
     analysisRequest.userAssignmentsList.push(intentionEval);
 
     cell.attributes.nodeID = intention.nodeID;
+
+    // embed in any actors below
+    embedBasicActor(cell);
 }
 
 /**

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -679,27 +679,6 @@ function createIntention(cell) {
 
     cell.attributes.nodeID = intention.nodeID;
 
-    // when the intention is removed, remove the intention from the global
-    // model variable as well
-    cell.on("remove", function () {
-        console.log("removed 685");
-    	clearInspector();
-    	var userIntention = model.getIntentionByID(cell.attributes.nodeID);
-    	// remove this intention from the model
-       // model.removeIntention(userIntention.nodeID);
-        // remove all intention evaluations associated with this intention
-        analysisRequest.removeIntention(userIntention.nodeID);
-
-        // if this intention has an actor, remove this intention's ID
-        // from the actor
-        if (userIntention.nodeActorID !== '-') {
-        	var actor = model.getActorByID(userIntention.nodeActorID);
-        	actor.removeIntentionID(userIntention.nodeID, analysisRequest.userAssignmentsList);
-            console.log('removed node cell.on line 697');
-        }
-
-    });
-
     /**
      * Testing drag/drop behavior
      */
@@ -707,7 +686,7 @@ function createIntention(cell) {
 
         console.log("dragging");
 
-        // Unembed intention so you can move it out of actor
+        // Unembed intention so user can move it out of actor
         if (cell.get('parent') && !(cell instanceof joint.dia.Link)) {
             graph.getCell(cell.get('parent')).unembed(cell);
 
@@ -715,7 +694,7 @@ function createIntention(cell) {
             var userIntention = model.getIntentionByID(cell.attributes.nodeID);
             if (userIntention.nodeActorID !== '-') {
                 var actor = model.getActorByID(userIntention.nodeActorID);
-                actor.removeIntentionID(userIntention.nodeID, analysisRequest.userAssignmentsList);
+                actor.removeIntentionID(userIntention.nodeID);
             }
         }
     });
@@ -725,7 +704,6 @@ function createIntention(cell) {
         // not link
         if (!(cell instanceof joint.dia.Link)){
             // embed in actor
-            console.log("embedding in actor");
             embedBasicActor(cell);
         }
     });
@@ -1080,13 +1058,26 @@ paper.on('cell:pointerdown', function(cellView, evt, x, y) {
 	if (cell instanceof joint.dia.Link){
 		cell.reparent();
 	}
+
+    // Unembed intention so user can move it out of actor
+    if (cell.get('parent') && !(cell instanceof joint.dia.Link)) {
+        graph.getCell(cell.get('parent')).unembed(cell);
+
+        // remove nodeID from actor intentionIDs list
+        var userIntention = model.getIntentionByID(cell.attributes.nodeID);
+        if (userIntention.nodeActorID !== '-') {
+            var actor = model.getActorByID(userIntention.nodeActorID);
+            actor.removeIntentionID(userIntention.nodeID);
+        }
+    }
 });
 
+/** 
 paper.on('element:mouseover', function(cellView, evt, x, y) {
 	var cell = cellView.model;
 	console.log('mouseover');
     console.log(cell);
-});
+});*/
 
 paper.on('element:dragEnd', function(cellView, evt, x, y) {
 	var cell = cellView.model;
@@ -1228,6 +1219,12 @@ paper.on('cell:pointerup', function(cellView, evt) {
 
             currentHalo = createHalo(cellView);
 
+            // not link
+            if (!(cellView.model instanceof joint.dia.Link)){
+                // embed in actor
+                embedBasicActor(cellView.model);
+            }
+
             clearInspector();
 
             if (cellView.model instanceof joint.shapes.basic.Actor) {
@@ -1257,7 +1254,7 @@ function embedBasicActor(cell) {
 					var nodeID = cell.attributes.nodeID;
 					var actorID = actorCell.attributes.nodeID
 					model.getIntentionByID(nodeID).nodeActorID = actorID;
-					model.getActorByID(actorID).intentionIDs.push(nodeID);
+					model.getActorByID(actorID).addIntentionID(nodeID);
 				}
 			}
 		}
@@ -1301,10 +1298,11 @@ graph.on('remove', function(cell) {
         // from the actor
         if (userIntention.nodeActorID !== '-') {
             var actor = model.getActorByID(userIntention.nodeActorID);
-            console.log(model);
-            actor.removeIntentionID(userIntention.nodeID,analysisRequest.userAssignmentsList);
+            //console.log(model);
+            actor.removeIntentionID(userIntention.nodeID);
             console.log('removed node graph.on line 1251');
-            console.log(model);
+            console.log(actor.intentionIDs);
+            //console.log(model);
         }
         model.removeIntention(userIntention.nodeID);
     }

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -682,6 +682,7 @@ function createIntention(cell) {
     // when the intention is removed, remove the intention from the global
     // model variable as well
     cell.on("remove", function () {
+        console.log("removed");
     	clearInspector();
     	var userIntention = model.getIntentionByID(cell.attributes.nodeID);
     	// remove this intention from the model
@@ -697,6 +698,36 @@ function createIntention(cell) {
             console.log('removed node cell.on line 697');
         }
 
+    });
+
+    /**
+     * Testing drag/drop behavior
+     */
+    cell.on('dragstart', function() {
+
+        console.log("dragging");
+
+        // Unembed intention so you can move it out of actor
+        if (cell.get('parent') && !(cell instanceof joint.dia.Link)) {
+            graph.getCell(cell.get('parent')).unembed(cell);
+
+            // remove nodeID from actor intentionIDs list
+            var userIntention = model.getIntentionByID(cell.attributes.nodeID);
+            if (userIntention.nodeActorID !== '-') {
+                var actor = model.getActorByID(userIntention.nodeActorID);
+                actor.removeIntentionID(userIntention.nodeID, analysisRequest.userAssignmentsList);
+            }
+        }
+    });
+
+    // drop cell in actor
+    cell.on('dragend', function() {
+        // not link
+        if (!(cell instanceof joint.dia.Link)){
+            // embed in actor
+            console.log("embedding in actor");
+            embedBasicActor(cell);
+        }
     });
 
 }
@@ -1044,18 +1075,6 @@ paper.on('cell:pointerdown', function(cellView, evt, x, y) {
 	if (cell instanceof joint.dia.Link){
 		cell.reparent();
 	}
-
-	// Unembed intention so you can move it out of actor
-	if (cell.get('parent') && !(cell instanceof joint.dia.Link)) {
-		graph.getCell(cell.get('parent')).unembed(cell);
-
-        // remove nodeID from actor intentionIDs list
-        var userIntention = model.getIntentionByID(cell.attributes.nodeID);
-        if (userIntention.nodeActorID !== '-') {
-            var actor = model.getActorByID(userIntention.nodeActorID);
-            actor.removeIntentionID(userIntention.nodeID, analysisRequest.userAssignmentsList);
-        }
-	}
 });
 
 // Unhighlight everything when blank is being clicked
@@ -1179,8 +1198,6 @@ paper.on('cell:pointerup', function(cellView, evt) {
             cellView.highlight();
 
             currentHalo = createHalo(cellView);
-
-            embedBasicActor(cellView.model);
 
             clearInspector();
 

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -647,14 +647,6 @@ function createLink(cell) {
 			link.linkSrcID = source.attributes.nodeID;
 		}
     });
-
-    // when the link is removed, remove the link from the global model
-    // variable as well
-    cell.on("remove", function () {
-    	clearInspector();
-		model.removeLink(link.linkID);
-        console.log("removelink line 656");
-    });
     model.links.push(link);
 }
 
@@ -693,13 +685,6 @@ function createActor(cell) {
     cell.attr(".name/text", name);
 	cell.attributes.nodeID = actor.nodeID;
 	model.actors.push(actor);
-
-	// when the actor is removed, remove the actor from the
-	// global model variable as well
-	cell.on('remove', function() {
-		model.removeActor(actor.nodeID);
-        console.log('remove actor line 700');
-	});
 }
 
 /**
@@ -1013,7 +998,7 @@ paper.on('blank:pointerdown', function(evt, x, y) {
 });
 
 /**
- * Specifies behavior for clicking on cells: setting selections, 
+ * Specifies behavior for clicking on cells and moving intentions/links
  */
 paper.on({
     'cell:pointerdown': function(cellView, evt, x, y) {
@@ -1026,10 +1011,9 @@ paper.on({
         evt.data = {move: false, interact: interact};
     },
     'cell:pointermove': function(cellView, evt, x, y) {
-        if (evt.data.interact){
-            // a click and drag
+        if (!evt.data.move && evt.data.interact){
+            // start of a click and drag
             evt.data.move = true;
-            console.log('moved cell');
         }
       },
     'cell:pointerup': function(cellView, evt, x, y) {
@@ -1040,9 +1024,7 @@ paper.on({
             if (cell instanceof joint.dia.Link) {
                 if (evt.data.move){
                     // if link moved, reparent
-                    console.log(model);
                     cell.reparent();
-                    console.log(model);
                     // check if link still valid
                     basicActorLink(cell);
                 }
@@ -1083,7 +1065,6 @@ paper.on({
                         }
                         // embed element in new actor
                         embedBasicActor(cell);
-                        console.log(model);
                     }
                 }
             }


### PR DESCRIPTION
This branch resolves multiple bugs and cleans up code related to the interaction of actors and intentions:

- actors stored duplicate nodeIDs from every time an intention was re-added to the actor — now such duplication is prevented
- actors did not remove nodeIDs from their intentionID lists when intentions were dragged out of the actor — fixed this removal process
- intentions could not reparent to no actor (`'-'`) when dragged out of all actors — added this functionality
- intentions were removed and re-added to the actor on every click — now they are only removed and re-added when dragged; same with reparenting links
- removing intentions from actors also removed the intentions from the userAssignmentsList (UAL), even if the intention wasn't removed from the model — this duplicate and sometimes incorrect functionality was deleted because other existing code already removes intentions from the UAL in all proper places
- `cell.on('remove'...)` behavior did not run for intentions, links, and actors loaded from a saved model — these functions were deleted because the exact same behavior exists in `paper.on('remove'...)` and works for both loaded and non-loaded models

In addition, these changes restructure `'cell:pointerdown'`,  `'cell:pointermove'`, and `'cell:pointerup'`events to distinguish between clicking and dragging an intention/link, such that intentions/links only get re-embedded/reparented when moved rather than every time the user clicks them. There are also small changes to simplify the logic flow in these events, such as not checking whether a cell is a Link inside an `else` statement that only runs when the cell is not a Link.

All these changes are intended to address the bug in `model-management` where clicking on an intention changes the model, since every time the intention was clicked, it would be removed from the actor below (without actually being removed, due to a bug) and then re-embedded in the actor (with duplication allowed in the actor's intentionsID list). The combo of these two bugs added an extra copy of the intention's nodeID to the actor every time the intention was clicked. Now, these and related bugs are resolved, and the process is more efficient because intentions will only be removed and re-embeded when dragged by the user.

Linked issues: fixes #312 