### PR TITLE
Model management "final" bug fixes

### DIFF
--- a/leaf-ui/css/analysis_style.css
+++ b/leaf-ui/css/analysis_style.css
@@ -344,6 +344,13 @@ select::-ms-expand {
     outline: none;  
     width: 71%;
   }
+
+  .config-input {
+    padding: 10px; 
+    font-size: 16px; 
+    border: 1px solid black; 
+    outline: none;  
+  }
   
   .dropdown-button {
     padding: 2px 7px 4px 7px; 
@@ -365,6 +372,7 @@ select::-ms-expand {
     border: none; 
     outline: none;
     box-shadow: -1px 0px 0px 0px rgb(71, 65, 65);
+    float: left;
     cursor: pointer;
   }
 

--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -168,8 +168,8 @@
         </div>
          
         <div id="stencil" class="left-panel"><label>Stencil</label></div>
-        <div id="analysis-sidebar" class="left-panel"><h3 style="text-align:left; color:#181b1fe3; margin-bottom:5px; margin-left: 10px;">Analysis
-            <div class="addConfig" style="display:inline">
+        <div id="analysis-sidebar" class="left-panel" style="display:none"><h3 style="text-align:left; color:#181b1fe3; margin-bottom:5px; margin-left: 10px;">Analysis
+            <div id="addConfig" style="display:inline">
                 <i class="fa fa-plus" id="addIntent" style="font-size:30px; float:right;  margin-bottom:5px; margin-right:20px;"></i>
             </div></h3>
             <div id="configurations" class="left-panel" style="margin-top:20px; overflow-y:auto; height:69%; box-shadow: none;"></div>

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -200,9 +200,6 @@ function updateNodeValues(nodeID, satValue) {
 function addFirstAnalysisConfig(){
     // reset to default analysisRequest while preserving userAssignmentsList
     defaultAnalysisRequest();
-    // reset background colors
-    $(".config-elements").css("background-color", "");
-    $(".result-elements").css("background-color", "");
     // reset highest position to 1
     highestPosition = 1;
     // add config 1
@@ -312,9 +309,7 @@ function removeConfiguration(configElement) {
     // Highlight the currAnalysisConfig in the UI
     newConfigElement = document.getElementById(currAnalysisConfig.id);
     analysisRequest = currAnalysisConfig.getAnalysisRequest();
-    $(".config-elements").css("background-color", "");
-    $(".result-elements").css("background-color", "");
-    $(newConfigElement.querySelector('.config-elements')).css("background-color", "#A9A9A9");
+    switchSelectedShadingConfig(newConfigElement);
     // Remove full configuration div (includes results)
     configElement.remove();
     // Remove config from analysisMap
@@ -333,7 +328,6 @@ function clearAnalysisConfigSidebar() {
  * Loads in results to the UI menu when file is being loaded into BloomingLeaf
  */
 function loadResults(config){
-    $(".result-elements").css("background-color", "");
     var id = config.id;
 
     var dropdownElement = document.getElementById(id).querySelector('.dropdown-container');
@@ -346,15 +340,14 @@ function loadResults(config){
         dropdownElement.insertAdjacentHTML("beforeend","<a class='result-elements' id='"+i+"'>" + "Result " + (i+1) + "</a>");
     }
 
-    // Highlight last result
-    $(dropdownElement.lastChild).css("background-color", "#A9A9A9");
+    // highlight newest/last result
+    switchSelectedShadingResult($(dropdownElement.lastChild) /** last result */, dropdownElement.closest('.analysis-configuration') /** configuration element */);
 
 }
 /**
  * Adds result to UI menu
  */
 function updateResults(){
-    $(".result-elements").css("background-color", "");
     var id = currAnalysisConfig.id;
 
     // Get dropdown element and current result count from current config
@@ -365,7 +358,7 @@ function updateResults(){
     dropdownElement.insertAdjacentHTML("beforeend","<a class='result-elements' id='"+(resultCount-1)+"'>" + "Result " + (resultCount) + "</a>");
 
     // highlight newest/last result
-    $(dropdownElement.lastChild).css("background-color", "#A9A9A9");
+    switchSelectedShadingResult($(dropdownElement.lastChild) /** last result */, dropdownElement.closest('.analysis-configuration') /** configuration element */);
     
     refreshAnalysisUI();
 }
@@ -504,8 +497,7 @@ function switchConfigs(configElement){
     // restore default analysis view
     hideAnalysis();
     
-    $(".config-elements").css("background-color", "");
-    $(".result-elements").css("background-color", "");
+    switchSelectedShadingConfig(configElement);
     $(configElement.querySelector('.config-elements')).css("background-color", "#A9A9A9");
 }
 
@@ -519,10 +511,7 @@ function switchResults(resultElement, configElement){
     analysisRequest = currAnalysisConfig.getAnalysisRequest();
 
     // Update UI accordingly
-    $(".result-elements").css("background-color", "");
-    $(".config-elements").css("background-color", "");
-    $(resultElement).css("background-color", "#A9A9A9");
-    $(configElement.querySelector(".config-elements")).css("background-color","#A9A9A9");
+    switchSelectedShadingResult(resultElement, configElement);
     refreshAnalysisUI();
     displayAnalysis(currAnalysisResults, true);
     // show EVO analysis slider
@@ -533,9 +522,6 @@ function switchResults(resultElement, configElement){
     // perhaps it would be more useful to refresh EVO every time displayAnalysis() is called?
     // since it switches to modeling mode every time hideAnalysis() is called
     EVO.refresh();
-    // currAnalysisResults.colorVis.colorIntentionsAnalysis();
-    //document.getElementById("colorReset").value = EVO.sliderOption;
-    //document.getElementById("colorResetAnalysis").value = EVO.sliderOption;
 }
 
 /**
@@ -588,4 +574,30 @@ function defaultAnalysisRequest(){
     var defaultRequest = new AnalysisRequest();
     defaultRequest.userAssignmentsList = analysisRequest.userAssignmentsList;
     analysisRequest = defaultRequest;
+}
+
+/**
+ * Updates shading so that correct configuration is highlighted 
+ * when configuration is clicked
+ * 
+ * @param {JQueryElement} configElement 
+ */
+function switchSelectedShadingConfig(configElement){
+    $(".result-elements").css("background-color", "");
+    $(".config-elements").css("background-color", "");
+    $(configElement.querySelector(".config-elements")).css("background-color","#A9A9A9");
+}
+
+/**
+ * Updates shading so that correct configuration and result is highlighted 
+ * when result is clicked
+ * 
+ * @param {JQueryElement} resultElement
+ * @param {JQueryElement} configElement 
+ */
+function switchSelectedShadingResult(resultElement, configElement){
+    $(".result-elements").css("background-color", "");
+    $(".config-elements").css("background-color", "");
+    $(resultElement).css("background-color", "#A9A9A9");
+    $(configElement.querySelector(".config-elements")).css("background-color","#A9A9A9");
 }

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -190,6 +190,7 @@ function updateNodeValues(nodeID, satValue) {
         // Add a new, empty config to the map
         addFirstAnalysisConfig();
     }
+    // Refresh the analysis sidebar to reflect current analysis request values
     refreshAnalysisUI();
 }
 
@@ -310,7 +311,7 @@ function removeConfiguration(configElement) {
     }
     // Highlight the currAnalysisConfig in the UI
     newConfigElement = document.getElementById(currAnalysisConfig.id);
-    analysisRequest = currAnalysisConfig;
+    analysisRequest = currAnalysisConfig.getAnalysisRequest();
     $(".config-elements").css("background-color", "");
     $(".result-elements").css("background-color", "");
     $(newConfigElement.querySelector('.config-elements')).css("background-color", "#A9A9A9");
@@ -388,19 +389,22 @@ function updateResults(){
  * in places such as the right sidebar and absolute time points field
  */
 function refreshAnalysisUI(){
-    $('#abs-time-pts').val(analysisRequest.absTimePtsArr);
     $('#conflict-level').val(analysisRequest.conflictLevel);
     $('#num-rel-time').val(analysisRequest.numRelTime);
+    $('#abs-time-pts').val(analysisRequest.absTimePtsArr);
 
     // conflict-level and num-rel-time only interactive
     // until results generated from configuration
-    console.log(currAnalysisConfig);
     if (currAnalysisConfig.analysisResults.length > 0){
-        $("#conflict-level").prop('disabled', true);
+        $('#conflict-level').prop('disabled', true);
         $('#num-rel-time').prop('disabled', true);
+        $('#abs-time-pts').prop('disabled', true);
+        $('#max-abs-time').prop('disabled', true);
     } else {
-        $("#conflict-level").prop('disabled', false);
+        $('#conflict-level').prop('disabled', false);
         $('#num-rel-time').prop('disabled', false);
+        $('#abs-time-pts').prop('disabled', false);
+        $('#max-abs-time').prop('disabled', false);
     }
 }
 

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -310,6 +310,7 @@ function removeConfiguration(configElement) {
     }
     // Highlight the currAnalysisConfig in the UI
     newConfigElement = document.getElementById(currAnalysisConfig.id);
+    analysisRequest = currAnalysisConfig;
     $(".config-elements").css("background-color", "");
     $(".result-elements").css("background-color", "");
     $(newConfigElement.querySelector('.config-elements')).css("background-color", "#A9A9A9");

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -185,27 +185,32 @@ function updateNodeValues(nodeID, satValue) {
  * 
  */
  function loadAnalysisConfig(){
-    // Refresh the analysis sidebar to reflect current analysis request values
-    refreshAnalysisUI();
     // if there are no configs in the map
     if(analysisMap.size == 0){
         // Add a new, empty config to the map
         addFirstAnalysisConfig();
     }
+    refreshAnalysisUI();
 }
 
 /**
  * Function to set up the initial analysis configuration upon page load
  */
 function addFirstAnalysisConfig(){
+    // reset to default analysisRequest while preserving userAssignmentsList
+    defaultAnalysisRequest();
+    // reset background colors
     $(".config-elements").css("background-color", "");
     $(".result-elements").css("background-color", "");
+    // reset highest position to 1
     highestPosition = 1;
+    // add config 1
     var id = ("Configuration" + highestPosition);
     currAnalysisConfig = new AnalysisConfiguration(id, analysisRequest, highestPosition);
     analysisMap.set(id, currAnalysisConfig);
     // Add the empty first config to the UI
     addAnalysisConfig(currAnalysisConfig);
+    refreshAnalysisUI();
 }
 
 /**
@@ -360,6 +365,7 @@ function updateResults(){
     // highlight newest/last result
     $(dropdownElement.lastChild).css("background-color", "#A9A9A9");
     
+    refreshAnalysisUI();
 }
 
 /**
@@ -384,6 +390,17 @@ function refreshAnalysisUI(){
     $('#abs-time-pts').val(analysisRequest.absTimePtsArr);
     $('#conflict-level').val(analysisRequest.conflictLevel);
     $('#num-rel-time').val(analysisRequest.numRelTime);
+
+    // conflict-level and num-rel-time only interactive
+    // until results generated from configuration
+    console.log(currAnalysisConfig);
+    if (currAnalysisConfig.analysisResults.length > 0){
+        $("#conflict-level").prop('disabled', true);
+        $('#num-rel-time').prop('disabled', true);
+    } else {
+        $("#conflict-level").prop('disabled', false);
+        $('#num-rel-time').prop('disabled', false);
+    }
 }
 
 /**
@@ -553,4 +570,17 @@ function getConfigHtml(id){
             '</div>' +
             '<div class="dropdown-container"></div>' +
            '</div>';
+}
+
+/**
+ * Reset global analysisRequest to default analysisRequest settings
+ * while preserving userAssignmentsList
+ */
+function defaultAnalysisRequest(){
+    // restore initial userAssignmentsList - holds initial evals for each intention
+    analysisRequest.clearUserEvaluations();
+    // copy initial userAssignmentsList into otherwise default analysisRequest
+    var defaultRequest = new AnalysisRequest();
+    defaultRequest.userAssignmentsList = analysisRequest.userAssignmentsList;
+    analysisRequest = defaultRequest;
 }

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -189,9 +189,10 @@ function updateNodeValues(nodeID, satValue) {
     if(analysisMap.size == 0){
         // Add a new, empty config to the map
         addFirstAnalysisConfig();
-    }
+    } else {
     // Refresh the analysis sidebar to reflect current analysis request values
     refreshAnalysisUI();
+    }
 }
 
 /**
@@ -199,7 +200,7 @@ function updateNodeValues(nodeID, satValue) {
  */
 function addFirstAnalysisConfig(){
     // reset to default analysisRequest while preserving userAssignmentsList
-    defaultAnalysisRequest();
+    resetToDefault();
     // reset highest position to 1
     highestPosition = 1;
     // add config 1
@@ -567,7 +568,7 @@ function getConfigHtml(id){
  * Reset global analysisRequest to default analysisRequest settings
  * while preserving userAssignmentsList
  */
-function defaultAnalysisRequest(){
+function resetToDefault(){
     // restore initial userAssignmentsList - holds initial evals for each intention
     analysisRequest.clearUserEvaluations();
     // copy initial userAssignmentsList into otherwise default analysisRequest

--- a/leaf-ui/js/initializeElements.js
+++ b/leaf-ui/js/initializeElements.js
@@ -339,9 +339,6 @@ stencil.load([goal, task, sgoal, res, act]);
 // Setup LinkInspector
 $('.inspector').append(linkInspector.el);
 
-// Set up Analysis Config Sidebar as none for startup on modelling mode
-$('#analysis-sidebar').css("display","none");
-
 // Initialize Slider setup
 sliderObject.sliderElement = document.getElementById('slider');
 sliderObject.sliderValueElement = document.getElementById('sliderValue');

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -464,7 +464,7 @@ function getNodeID(rapID, cells) {
 }
 
 /**
- * Returns an object that contains the current graph, model.
+ * Returns an object that contains the current graph, model, and analysis request.
  * This return object is what the user would download when clicking the Save button
  * in the top menu bar.
  *
@@ -479,7 +479,7 @@ function getModelJson() {
 }
 
 /**
- * Returns an object that contains the current graph, model and analysis configurations
+ * Returns an object that contains the current graph, model, and analysis configurations
  * and REMOVES results from the analysisConfigurations map.
  * This return object is what the user would download when clicking the Save button
  * in the top menu bar.

--- a/leaf-ui/js/object/Class.js
+++ b/leaf-ui/js/object/Class.js
@@ -1889,8 +1889,6 @@ class AnalysisRequest {
      *
      * @param {String}
      */
-
-
     removeIntention(nodeID) {
         var i = 0;
 

--- a/leaf-ui/js/objects.js
+++ b/leaf-ui/js/objects.js
@@ -100,7 +100,6 @@ class ChartObj {
 	}
 }
 
-// TODO: Clean up this config. We potentially only need the id, analysisRequest, and analysisResults params
 class AnalysisConfiguration {
 	/**
 	 * This class is used to hold analysis configuration specifications and results 
@@ -110,11 +109,6 @@ class AnalysisConfiguration {
 	 * @param {String} id
 	 * @param {AnalysisRequest} analysisRequest
 	 * @param {Int} initialPosition
-     * @param {String} action
-     * @param {String} conflictLevel
-     * @param {String} numRelTime
-     * @param {String} absTimePts
-     * @param {String} currentState
      * @param {Array.<UserEvaluation>} userAssignmentsList
      * @param {Array.<AnalysisResult>} analysisResults
 	 */
@@ -122,12 +116,6 @@ class AnalysisConfiguration {
 	constructor(id, analysisRequest, initialPosition) {
 		this.id = id;
 		this.analysisRequest = analysisRequest;
-		this.action = analysisRequest.action;
-        this.conflictLevel = analysisRequest.conflictLevel;
-        this.numRelTime = analysisRequest.numRelTime;
-        this.absTimePts = analysisRequest.absTimePts;
-        this.absTimePtsArr = analysisRequest.absTimePtsArr;
-        this.currentState = analysisRequest.currentState;
         this.userAssignmentsList = analysisRequest.userAssignmentsList;
         this.analysisResults = [];
 		this.initialPosition = initialPosition;
@@ -169,12 +157,6 @@ class AnalysisConfiguration {
 	 */
 	updateAnalysis(analysisRequest){
 		this.analysisRequest = analysisRequest;
-		this.action = analysisRequest.action;
-        this.conflictLevel = analysisRequest.conflictLevel;
-        this.numRelTime = analysisRequest.numRelTime;
-        this.absTimePts = analysisRequest.absTimePts;
-        this.absTimePtsArr = analysisRequest.absTimePtsArr;
-        this.currentState = analysisRequest.currentState;
 		this.userAssignmentsList = analysisRequest.userAssignmentsList;
 	}
 

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -464,7 +464,7 @@ function switchToAnalysisMode() {
     $('.model-clears').css("display", "none");
     $('.analysis-clears').css("display", "");
 
-
+    // Show Analysis View tag
 	$('#modeText').text("Analysis View");
 
 	// Disable link settings
@@ -571,6 +571,9 @@ function switchToModellingMode() {
     $('.analysis-clears').css("display", "none");
 
     analysisResult.colorVis = [];
+
+    // Show Modelling View tag
+    $('#modeText').text("Modeling View");
 
 	// Reinstantiate link settings
 	$('.link-tools .tool-remove').css("display","");

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -128,6 +128,41 @@ $('#load-sample').on('click', function() {
     });
 });
 
+/** Analysis Configuration Sidebar */
+
+/**
+ * Adds a new AnalysisConfig
+ */
+ $('#addConfig').on('click', function(){
+    addNewAnalysisConfig();
+});
+
+/**
+ * Allows user to rename configuration element on doubleclick
+ */
+$(document).on('dblclick', '.config-elements', function(e){rename(e.target /** Config element */)});
+
+/**
+ * Switches UI to clicked configuration element
+ */
+$(document).on('click', '.config-elements', function(e){switchConfigs(e.target.closest('.analysis-configuration') /** Config element */)});
+   
+/**
+ * Toggles results dropdown menu on click of dropdown arrow
+ */
+$(document).on('click','.dropdown-button', function(e){toggleDropdown(e.target.closest('.analysis-configuration') /** Config element */)});
+
+/**
+ * Deletes configuration from UI and analysisMap on click of delete button
+ */
+$(document).on('click','.deleteconfig-button', function(e){removeConfiguration(e.target.closest('.analysis-configuration') /** Config element */)});
+
+/**
+ * Switches to clicked result and it's corresponding configuration in UI
+ */
+$(document).on('click', '.result-elements', function(e){switchResults(e.target /** Result element */, e.target.closest('.analysis-configuration') /** Config element */)})
+
+
 /**
  * Trigger when unassign button is pressed. 
  * Change the assigned time of the node/link in the same row to none
@@ -1424,22 +1459,6 @@ function checkForMultipleNB(node) {
 	}
 
 	return num >= 1;
-}
-
-/**
- * Function to add first analysis configuration 
- * if no configs exist when switching to analysis mode
- * If the analysisMap contains configurations loaded from JSON, populate the sidebar
- * 
- */
-function loadAnalysisConfig(){
-    // Refresh the analysis sidebar to reflect current analysis request values
-    refreshAnalysisUI();
-    // if there are no configs in the map
-    if(analysisMap.size == 0){
-        // Add a new, empty config to the map
-        addFirstAnalysisConfig();
-    }
 }
 
 /**

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -681,12 +681,7 @@ $('#btn-clear-cycle').on('click',function(){
 
 $('#btn-clear-analysis').on('click', function() {
     // reset to default analysisRequest while preserving userAssignmentsList
-    // restore initial userAssignmentsList - holds initial evals for each intention
-    analysisRequest.clearUserEvaluations();
-    // copy initial userAssignmentsList into otherwise default analysisRequest
-    var defaultRequest = new AnalysisRequest();
-    defaultRequest.userAssignmentsList = analysisRequest.userAssignmentsList;
-    analysisRequest = defaultRequest;
+    defaultAnalysisRequest();
     // clear analysis sidebar
     clearAnalysisConfigSidebar();
     // remove all configs from analysisMap
@@ -699,6 +694,7 @@ $('#btn-clear-analysis').on('click', function() {
 
 $('#btn-clear-results').on('click', function() {
     clearResults();
+    refreshAnalysisUI();
 });
 
 // Open as SVG

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -684,7 +684,7 @@ $('#btn-clear-cycle').on('click',function(){
 
 $('#btn-clear-analysis').on('click', function() {
     // reset to default analysisRequest while preserving userAssignmentsList
-    defaultAnalysisRequest();
+    resetToDefault();
     // clear analysis sidebar
     clearAnalysisConfigSidebar();
     // remove all configs from analysisMap


### PR DESCRIPTION
Working with Ali @leshghi on some final bugs in model-management before the launch of Version 1.5!

- Cleaned up the AnalysisConfiguration class structure
- Disabled ways to edit analysis configuration after generating results from it (won't fix intermediate values in this version)
- Fixed the renaming feature to remove bug and clean up CSS
- Fixed bug where analysisRequest didn't update after deleting a selected config
- Fixed sidebar loading bug where analysis config sidebar would briefly pop up on page load
- Removed individual event listeners from elements and put listeners in onFunctions per JavaScript convention
- Put css updates in their own functions in displayAnalysis
- Cleaned up some comments, empty spaces, and console logs