### PR TITLE
issue #375 And/Or end selections fixed

### DIFF
--- a/leaf-ui/rappid-extensions/LinkInspector.js
+++ b/leaf-ui/rappid-extensions/LinkInspector.js
@@ -247,13 +247,9 @@ var LinkInspector = Backbone.View.extend({
             // save into link object
             this.link.linkType = begin.toUpperCase();
             this.link.postType = 'NO';
-
-            $("#repeat-error").text("Saved!");
-            $("#repeat-error").css("color", "lightgreen");
-
         } else {
             this.setSelectValues('#link-type-end', "B");
-            $("#link-type-end").prop('disabled', '');
+            $("#link-type-end").prop('disabled', false);
             $("#link-type-end").css("background-color","");
         }
     },
@@ -352,9 +348,9 @@ var LinkInspector = Backbone.View.extend({
                 element.append($("<option></option>").attr("value", value).text(key));
             });
         } else if (type == "A") {
-            element.val("no");
-            $("#repeat-error").text("Saved!");
-            $("#repeat-error").css("color", "lightgreen");
+            $.each(relationA, function (value, key) {
+                element.append($("<option></option>").attr("value", value).text(key));
+            });
         } else if (type == "B") {
             $.each(relationB, function (value, key) {
                 element.append($("<option></option>").attr("value", value).text(key));


### PR DESCRIPTION
For issue #375, when the begin is and/or, the program used to make the end "no relationship." Now it is fixed, and users can select from template A.

I also changed the syntax in line 256 from '' to false.