### PR TITLE
Fixed: issue #374 in LinkInspector

### DIFF
--- a/leaf-ui/rappid-extensions/LinkInspector.js
+++ b/leaf-ui/rappid-extensions/LinkInspector.js
@@ -247,9 +247,13 @@ var LinkInspector = Backbone.View.extend({
             // save into link object
             this.link.linkType = begin.toUpperCase();
             this.link.postType = 'NO';
+
+            $("#repeat-error").text("Saved!");
+            $("#repeat-error").css("color", "lightgreen");
+
         } else {
             this.setSelectValues('#link-type-end', "B");
-            $("#link-type-end").prop('disabled', false);
+            $("#link-type-end").prop('disabled', '');
             $("#link-type-end").css("background-color","");
         }
     },
@@ -348,9 +352,9 @@ var LinkInspector = Backbone.View.extend({
                 element.append($("<option></option>").attr("value", value).text(key));
             });
         } else if (type == "A") {
-            $.each(relationA, function (value, key) {
-                element.append($("<option></option>").attr("value", value).text(key));
-            });
+            element.val("no");
+            $("#repeat-error").text("Saved!");
+            $("#repeat-error").css("color", "lightgreen");
         } else if (type == "B") {
             $.each(relationB, function (value, key) {
                 element.append($("<option></option>").attr("value", value).text(key));

--- a/leaf-ui/rappid-extensions/LinkInspector.js
+++ b/leaf-ui/rappid-extensions/LinkInspector.js
@@ -248,12 +248,10 @@ var LinkInspector = Backbone.View.extend({
             this.link.linkType = begin.toUpperCase();
             this.link.postType = 'NO';
 
-            $("#repeat-error").text("Saved!");
-            $("#repeat-error").css("color", "lightgreen");
 
         } else {
             this.setSelectValues('#link-type-end', "B");
-            $("#link-type-end").prop('disabled', '');
+            $("#link-type-end").prop('disabled', false);
             $("#link-type-end").css("background-color","");
         }
     },
@@ -352,9 +350,9 @@ var LinkInspector = Backbone.View.extend({
                 element.append($("<option></option>").attr("value", value).text(key));
             });
         } else if (type == "A") {
-            element.val("no");
-            $("#repeat-error").text("Saved!");
-            $("#repeat-error").css("color", "lightgreen");
+            $.each(relationA, function (value, key) {
+                element.append($("<option></option>").attr("value", value).text(key));
+            });
         } else if (type == "B") {
             $.each(relationB, function (value, key) {
                 element.append($("<option></option>").attr("value", value).text(key));

--- a/leaf-ui/rappid-extensions/LinkInspector.js
+++ b/leaf-ui/rappid-extensions/LinkInspector.js
@@ -247,13 +247,9 @@ var LinkInspector = Backbone.View.extend({
             // save into link object
             this.link.linkType = begin.toUpperCase();
             this.link.postType = 'NO';
-
-            $("#repeat-error").text("Saved!");
-            $("#repeat-error").css("color", "lightgreen");
-
         } else {
             this.setSelectValues('#link-type-end', "B");
-            $("#link-type-end").prop('disabled', '');
+            $("#link-type-end").prop('disabled', false);
             $("#link-type-end").css("background-color","");
         }
     },
@@ -352,9 +348,9 @@ var LinkInspector = Backbone.View.extend({
                 element.append($("<option></option>").attr("value", value).text(key));
             });
         } else if (type == "A") {
-            element.val("no");
-            $("#repeat-error").text("Saved!");
-            $("#repeat-error").css("color", "lightgreen");
+            $.each(relationA, function (value, key) {
+                element.append($("<option></option>").attr("value", value).text(key));
+            });
         } else if (type == "B") {
             $.each(relationB, function (value, key) {
                 element.append($("<option></option>").attr("value", value).text(key));


### PR DESCRIPTION
Before, when user selects and/or as the begin, the code automatically assigns end with NO. Now the user can select from template A. 