### PR TITLE
EVO-related issues with satvalue and slider

### DIFF
--- a/leaf-ui/js/backendComm.js
+++ b/leaf-ui/js/backendComm.js
@@ -130,6 +130,7 @@ function responseFunc(analysisRequest, response) {
 				var analysisResult = convertToAnalysisResult(results); 	// {ResultBBM}
 				displayAnalysis(analysisResult, false);
 				analysisRequest.addResult(analysisResult);
+				EVO.refresh(analysisRequest);
 		} else {
 			alert("Error: Unknown analysis request type.");
 			return;

--- a/leaf-ui/js/backendComm.js
+++ b/leaf-ui/js/backendComm.js
@@ -130,7 +130,6 @@ function responseFunc(analysisRequest, response) {
 				var analysisResult = convertToAnalysisResult(results); 	// {ResultBBM}
 				displayAnalysis(analysisResult, false);
 				analysisRequest.addResult(analysisResult);
-				EVO.refresh(analysisRequest);
 		} else {
 			alert("Error: Unknown analysis request type.");
 			return;

--- a/leaf-ui/js/displayAnalysis.js
+++ b/leaf-ui/js/displayAnalysis.js
@@ -84,7 +84,7 @@ function createSlider(currentAnalysis, isSwitch) {
     sliderObject.sliderElement.noUiSlider.on('update', function( values, handle ) {
         updateSliderValues(parseInt(values[handle]), currentAnalysis);
     });
-    EVO.setCurTimePoint(sliderMax, currentAnalysis);
+    EVO.setCurTimePoint(isSwitch ? 0 : sliderMax, currentAnalysis);
     adjustSliderWidth(sliderMax);
 }
 

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -145,7 +145,7 @@ class EVO {
      * Runs after any event that may change visualization, such as setting a sat value, changing slider option, or selecting a time point
      */
     static refresh(analysisResult) {
-        if (this.sliderOption > 0) {
+        if (EVO.sliderOption > 0) {
             if (analysisResult !== undefined){
                 if (analysisResult.get('selected')){
                     EVO.colorIntentionsAnalysis(analysisResult);
@@ -159,9 +159,19 @@ class EVO {
             }
             EVO.changeIntentionsText(analysisResult);
         } else {
+            if (analysisResult !== undefined) {
+                if (analysisResult.get('selected')) {
+                    EVO.displaySlider(true);
+                }
+                else {
+                    EVO.displaySlider(false);
+                }
+            }
+            else {
+                EVO.displaySlider(false);
+            }
             EVO.returnAllColors(graph.getElements(), paper);
             EVO.revertIntentionsText(graph.getElements(), paper);
-            EVO.displaySlider(false);
         }
     }
         
@@ -367,6 +377,7 @@ class EVO {
 
         // Shows .satvalue automatically
         $('.satvalue').css("display", "");
+
         for (var i = 0; i < elements.length; i++) {
             curr = elements[i].findView(paper).model;
 
@@ -420,12 +431,12 @@ class EVO {
     /** 
      * Makes slider dis/appear 
      */
-     static displaySlider(isState){
-        if (isState) {// If the sliderOption is set at state
+     static displaySlider(isOn){
+        if (isOn) {// If the sliderOption is set at state or off
             $('#slider').css("display", "");
             $('#sliderValue').css("display", "");
         }
-        else {// If the sliderOption is not set at state
+        else {// If the sliderOption is at % and time and when no result is selected
             $('#slider').css("display", "none");
             $('#sliderValue').css("display", "none");
         }

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -25,7 +25,7 @@ class IntentionColoring {
         if(newColorMode != "EVO") {
             EVO.deactivate();
         }
-        IntentionColoring.refresh(analysisResult);
+        EVO.refresh(analysisResult);
     }
 
     /**
@@ -34,7 +34,7 @@ class IntentionColoring {
      */
     static toggleColorBlindMode(isTurningOnColorBlindMode, analysisResult) {
         IntentionColoring.isColorBlindMode = isTurningOnColorBlindMode;
-        IntentionColoring.refresh(analysisResult);
+        EVO.refresh(analysisResult);
     }
         
 }
@@ -122,6 +122,7 @@ class EVO {
      * @param {*} newSliderOption 
      */
     static setSliderOption(newSliderOption, analysisResult) {
+        console.log("setSliderOption");
         if (newSliderOption >= 0 && newSliderOption <= 3) {
             EVO.sliderOption = newSliderOption;
         }
@@ -197,16 +198,6 @@ class EVO {
         }
         this.generateConsoleReport();
         EVO.refresh(analysisResult);
-    }   
-
-  
-    /**
-     * Switch between update modeling slider to analysis slider for EVO
-     */
-    static update(analysisResult){
-        $('#modelingSlider').css("display", "none");
-        $('#analysisSlider').css("display", "");
-        EVO.setSliderOption('1', analysisResult);
     }
 
   
@@ -511,16 +502,33 @@ class EVO {
     /**
      * Switch back to modeling slider, if EVO is on the visualization returns to filling by initial state.
      */
-     static switchToModelingMode(analysisResult, modelMode = true) {
+     static switchToModelingMode(analysisResult) {
         $('#modelingSlider').css("display", "");
         $('#analysisSlider').css("display", "none");
-        // if EVO is on in analysis mode, keep it on
-        if(EVO.sliderOption > 0 && modelMode) {
+
+        if(EVO.sliderOption > 0) {
             EVO.sliderOption = '1';
         }
         document.getElementById("colorReset").value = EVO.sliderOption;
         EVO.refresh(analysisResult);
 
+    }
+
+    static refreshSlider(analysisResult) {
+        if (analysisResult == undefined) {
+            $('#modelingSlider').css("display", "");
+            $('#analysisSlider').css("display", "none");
+            if(EVO.sliderOption > 0) {
+                EVO.sliderOption = '1';
+            }
+            document.getElementById("colorReset").value = EVO.sliderOption;
+        }
+        else {
+            $('#modelingSlider').css("display", "none");
+            $('#analysisSlider').css("display", "");
+            document.getElementById("colorResetAnalysis").value = EVO.sliderOption;
+        }
+        EVO.refresh(analysisResult);
     }
 
     /**

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -168,7 +168,6 @@ class EVO {
                 EVO.returnAllColors(graph.getElements(), paper);
                 EVO.revertIntentionsText(graph.getElements(), paper);
                 EVO.displaySlider(false);
-
                     break;
         }
     }

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -169,6 +169,7 @@ class EVO {
                 EVO.returnAllColors(graph.getElements(), paper);
                 EVO.revertIntentionsText(graph.getElements(), paper);
                 EVO.displaySlider(false);
+
                     break;
         }
     }
@@ -365,8 +366,10 @@ class EVO {
     static changeIntentionsText(analysisResult){
         var elements = graph.getElements();
         var curr;
-        var intention;
-        var initSatVal;
+        var timepoint;
+        var colorVis 
+        var satVal;
+        
         for (var i = 0; i < elements.length; i++) {
             curr = elements[i].findView(paper).model;
 
@@ -376,14 +379,18 @@ class EVO {
                 curr.attributes.type !== 'basic.Resource') {
                 continue;
             }
-            intention = elements[i].get('intention');
-            initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair');
 
             if (analysisResult !== undefined) {
                 curr = elements[i].findView(paper).model;
+                curr.attr({text: {fill: 'white',stroke:'none'}});
                 // If the result is selected 
                 if (analysisResult.get('selected')){
                     if (EVO.sliderOption == 3){
+                        // Resets the satvalue back
+                        timepoint = EVO.curTimePoint;
+                        colorVis = analysisResult.get('colorVis');
+                        satVal = colorVis.intentionListColorVis[0].timePoints[timepoint];
+                        curr.attr('.satvalue/text', satisfactionValuesDict[satVal].satValue);
                         $('.satvalue').css("display", "");
                         EVO.displaySlider(true);
                     }
@@ -425,8 +432,19 @@ class EVO {
      */
     static revertIntentionsText(elements, paper) {
         var curr;
+        var intention;
+        var initSatVal;
         for (var i = 0; i < elements.length; i++) {
+
             curr = elements[i].findView(paper).model;
+            intention = curr.get('intention');
+            initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair');
+
+            if (initSatVal === '(no value)') {
+                curr.attr('.satvalue/text', '');
+            } else {
+                curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
+            }
             curr.attr({text: {fill: 'black',stroke:'none'}});
         }
     }

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -205,12 +205,6 @@ class EVO {
         this.generateConsoleReport();
         EVO.refresh(analysisResult);
     }   
-    
-    static update(analysisResult){
-        $('#modelingSlider').css("display", "none");
-        $('#analysisSlider').css("display", "");
-        EVO.setSliderOption('1', analysisResult);
-    }
 
     /**
      * Turn off EVO
@@ -389,7 +383,7 @@ class EVO {
 
             // If there is result
             if (analysisResult !== undefined) {
-                
+
                 // If the result is selected 
                 if (analysisResult.get('selected')){
 

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -167,7 +167,8 @@ class EVO {
                 break;
             default://colorVis off
                 EVO.returnAllColors(graph.getElements(), paper);
-                EVO.revertIntentionsText(graph.getElements(), paper);    
+                EVO.revertIntentionsText(graph.getElements(), paper);
+                EVO.displaySlider(false);
                     break;
         }
     }
@@ -300,7 +301,7 @@ class EVO {
             }
 
             }
-            else if(EVO.sliderOption == 1) { //fill by %
+            else if (EVO.sliderOption == 1) { //fill by %
             for(var j = 0; j < EVO.numEvals; ++j) {
             var intentionEval = EVO.colorVisOrder[j];
             if(element.evals[intentionEval] > 0) {
@@ -377,40 +378,45 @@ class EVO {
             }
             intention = elements[i].get('intention');
             initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair');
-            
-            // Shows the satvalue
-            $('.satvalue').css("display", "");
 
-            // If there is result
             if (analysisResult !== undefined) {
-
+                curr = elements[i].findView(paper).model;
                 // If the result is selected 
                 if (analysisResult.get('selected')){
-
-                    if (this.sliderOption == 3){
-                        curr = elements[i].findView(paper).model;
-                        curr.attr({text: {fill: 'white',stroke:'none'}});
+                    if (EVO.sliderOption == 3){
+                        $('.satvalue').css("display", "");
+                        EVO.displaySlider(true);
                     }
-
                     else {
-                        // Sets the satvalue off
                         $('.satvalue').css("display", "none");
+                        EVO.displaySlider(false);
                     }
                 }
-
-                // If the result is not selected
                 else {
-                    if (initSatVal === '(no value)'){
-                        curr.attr('.satvalue/text', '');
-                        curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal'}});
-                    }
+                    curr.attr({text: {fill: 'black',stroke:'none'}});
+                    $('.satvalue').css("display", "");
+                    EVO.displaySlider(false);
                 }
             }
-            // If there isn't result
             else {
-                curr = elements[i].findView(paper).model;
-                curr.attr({text: {fill: 'white',stroke:'none'}});
+                curr.attr({text: {fill: 'black',stroke:'none'}});
+                $('.satvalue').css("display", "");
+                EVO.displaySlider(false);
             }
+        }
+    }
+
+    /** 
+     * Makes slider dis/appear 
+     */
+     static displaySlider(isState){
+        if (isState){
+            $('#slider').css("display", "");
+            $('#sliderValue').css("display", "");
+        }
+        else {
+            $('#slider').css("display", "none");
+            $('#sliderValue').css("display", "none");
         }
     }
 

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -21,7 +21,6 @@ class IntentionColoring {
      * @param {*} newColorMode 
      */
     static setColorMode(newColorMode, analysisResult) {
-        console.log("setColorMode");
         IntentionColoring.colorMode = newColorMode;
         if(newColorMode != "EVO") {
             EVO.deactivate();
@@ -344,7 +343,8 @@ class EVO {
             if (intention == null) { // If it is an actor or something went wrong
                 actorBuffer += 1;
             }
-            var element = analysisResult.get('colorVis').intentionListColorVis[i - actorBuffer];
+            if (analysisResult.get('colorVis') !== undefined) {
+                var element = analysisResult.get('colorVis').intentionListColorVis[i - actorBuffer];
                 if (intention != null && element != null) {
                     if (EVO.sliderOption != 3) {
                     var gradientID = this.defineGradient(element);
@@ -357,6 +357,7 @@ class EVO {
                         cellView.model.attr({'.outer' : {'fill' : color}});
                     }
                 }
+            }
         }
     }
 
@@ -369,7 +370,10 @@ class EVO {
         var timepoint;
         var colorVis 
         var satVal;
-        
+        var intention;
+        var initSatVal;
+
+        $('.satvalue').css("display", "");
         for (var i = 0; i < elements.length; i++) {
             curr = elements[i].findView(paper).model;
 
@@ -380,35 +384,41 @@ class EVO {
                 continue;
             }
 
+            // Sets satvalue/text to the initial sat value
+            intention = curr.get('intention');
+            initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair');
+            if (initSatVal === '(no value)') {
+                curr.attr('.satvalue/text', '');
+            } else {
+                curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
+            }
+
+            // The slider automatic setting
+            EVO.displaySlider(false);
+
             if (analysisResult !== undefined) {
-                curr = elements[i].findView(paper).model;
+                // The EVO mode fill color
                 curr.attr({text: {fill: 'white',stroke:'none'}});
                 // If the result is selected 
                 if (analysisResult.get('selected')){
-                    if (EVO.sliderOption == 3){
+                    if (EVO.sliderOption == 3){// If the option is states
                         // Resets the satvalue back
                         timepoint = EVO.curTimePoint;
                         colorVis = analysisResult.get('colorVis');
                         satVal = colorVis.intentionListColorVis[0].timePoints[timepoint];
                         curr.attr('.satvalue/text', satisfactionValuesDict[satVal].satValue);
-                        $('.satvalue').css("display", "");
                         EVO.displaySlider(true);
                     }
                     else {
                         $('.satvalue').css("display", "none");
-                        EVO.displaySlider(false);
                     }
                 }
                 else {
                     curr.attr({text: {fill: 'black',stroke:'none'}});
-                    $('.satvalue').css("display", "");
-                    EVO.displaySlider(false);
                 }
             }
             else {
                 curr.attr({text: {fill: 'black',stroke:'none'}});
-                $('.satvalue').css("display", "");
-                EVO.displaySlider(false);
             }
         }
     }
@@ -434,12 +444,14 @@ class EVO {
         var curr;
         var intention;
         var initSatVal;
+        // Displays .satvalue
+        $('.satvalue').css("display", "");
         for (var i = 0; i < elements.length; i++) {
-
             curr = elements[i].findView(paper).model;
             intention = curr.get('intention');
             initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair');
-
+            
+            // Sets satvalue/text to the initial sat value
             if (initSatVal === '(no value)') {
                 curr.attr('.satvalue/text', '');
             } else {
@@ -496,15 +508,15 @@ class EVO {
     /**
      * Switch back to modeling slider, if EVO is on the visualization returns to filling by initial state.
      */
-     static switchToModelingMode(analysisResult) {
+     static switchToModelingMode(analysisResult, modelMode = true) {
         $('#modelingSlider').css("display", "");
         $('#analysisSlider').css("display", "none");
         // if EVO is on in analysis mode, keep it on
-        if(EVO.sliderOption > 0) {
+        if(EVO.sliderOption > 0 && modelMode) {
             EVO.sliderOption = '1';
         }
         document.getElementById("colorReset").value = EVO.sliderOption;
-        IntentionColoring.refresh(analysisResult);
+        EVO.refresh(analysisResult);
     }
 }
 

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -1,7 +1,7 @@
 
 /**  
  * Prevents conflict in coloring modes. Refreshes when changes are made in the model.
- * EVO operates though IntentionColoring to allow for a deactivation mode
+ *
  */
 class IntentionColoring {
     static colorMode = "none"; //none, EVO, cycle
@@ -65,11 +65,12 @@ class IntentionColorVis{
     }
 }
 
-class EVO {
+
 /**
- * TODO: docstring 
+ * Colors the nodes based on the different EVO types 
  * 
  */
+class EVO {
 //replaced white with grey for readability
     static colorVisDict = {
         "0000" : "#D3D3D3",
@@ -114,7 +115,7 @@ class EVO {
     //user selected slider option
     static sliderOption = 0;
     //whether color blind mode is activated
-    //static isColorBlindMode = false;
+    static isColorBlindMode = false;
 
     /**
      * Checks validity, sets sliderOption, and refreshes visualization
@@ -127,11 +128,8 @@ class EVO {
         else {
             console.log("ERROR: invalid sliderOption");
         }
-        EVO.refresh(analysisResult);
 
-        if (EVO.sliderOption > 0) { //not off
-            IntentionColoring.setColorMode("EVO", analysisResult);
-        }
+        EVO.refresh(analysisResult);
     }
 
     /**
@@ -140,35 +138,30 @@ class EVO {
      */
     static setCurTimePoint(newTimePoint, analysisResult) {
         EVO.curTimePoint = newTimePoint;
-        IntentionColoring.refresh(analysisResult);
+        EVO.refresh(analysisResult);
     }
 
     /**
      * Runs after any event that may change visualization, such as setting a sat value, changing slider option, or selecting a time point
      */
     static refresh(analysisResult) {
-        switch(this.sliderOption) {
-            case '1':
-            case '2':
-            case '3':
-                if (analysisResult !== undefined){
-                    if (analysisResult.get('selected')){
-                        EVO.colorIntentionsAnalysis(analysisResult);
-                    }
-                    else {
-                        EVO.colorIntentionsModeling();
-                    }
+        if (this.sliderOption > 0) {
+            if (analysisResult !== undefined){
+                if (analysisResult.get('selected')){
+                    EVO.colorIntentionsAnalysis(analysisResult);
                 }
-                else{
+                else {
                     EVO.colorIntentionsModeling();
                 }
-                EVO.changeIntentionsText(analysisResult);
-                break;
-            default://colorVis off
-                EVO.returnAllColors(graph.getElements(), paper);
-                EVO.revertIntentionsText(graph.getElements(), paper);
-                EVO.displaySlider(false);
-                    break;
+            }
+            else{
+                EVO.colorIntentionsModeling();
+            }
+            EVO.changeIntentionsText(analysisResult);
+        } else {
+            EVO.returnAllColors(graph.getElements(), paper);
+            EVO.revertIntentionsText(graph.getElements(), paper);
+            EVO.displaySlider(false);
         }
     }
         
@@ -176,7 +169,7 @@ class EVO {
         this.numIntentions = elementList.length;
         this.numTimePoints = elementList[0].status.length;
         this.intentionListColorVis = [];  
-        this.isColorBlind = IntentionColoring.isColorBlindMode; // Assessable in next state window  
+        this.isColorBlind = false; // Assessable in next state window  
         this.initializeIntentionList();
     }  
 
@@ -206,6 +199,17 @@ class EVO {
         EVO.refresh(analysisResult);
     }   
 
+  
+    /**
+     * Switch between update modeling slider to analysis slider for EVO
+     */
+    static update(analysisResult){
+        $('#modelingSlider').css("display", "none");
+        $('#analysisSlider').css("display", "");
+        EVO.setSliderOption('1', analysisResult);
+    }
+
+  
     /**
      * Turn off EVO
      */
@@ -488,7 +492,7 @@ class EVO {
      * @param {*} intentionEval four digit code that corresponds to evidence pair (ex. 0011)
      */
     static getColor(intentionEval) {
-        if(IntentionColoring.isColorBlindMode) {
+        if (EVO.isColorBlindMode) {
             return EVO.colorVisDictColorBlind[intentionEval];
         }
         return EVO.colorVisDict[intentionEval];
@@ -516,6 +520,16 @@ class EVO {
         }
         document.getElementById("colorReset").value = EVO.sliderOption;
         EVO.refresh(analysisResult);
+
+    }
+
+    /**
+     * Toggles color blind mode
+     * @param {*} isTurningOnColorBlindMode 
+     */
+     static toggleColorBlindMode(isTurningOnColorBlindMode, analysisResult) {
+        EVO.isColorBlindMode = isTurningOnColorBlindMode;
+        EVO.refresh(analysisResult);
     }
 }
 
@@ -528,7 +542,7 @@ class EVONextState  {
      * This passes the color blind mode option through the Next State window
      */
     static setColorBlindFromPrevWindow() {
-        IntentionColoring.isColorBlindMode = window.opener.analysisResult.colorVis.isColorBlind;
+        EVO.isColorBlindMode = window.opener.analysisResult.colorVis.isColorBlind;
     }
 
     /**

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -122,7 +122,6 @@ class EVO {
      * @param {*} newSliderOption 
      */
     static setSliderOption(newSliderOption, analysisResult) {
-        console.log("setSliderOption");
         if (newSliderOption >= 0 && newSliderOption <= 3) {
             EVO.sliderOption = newSliderOption;
         }
@@ -361,12 +360,12 @@ class EVO {
     static changeIntentionsText(analysisResult){
         var elements = graph.getElements();
         var curr;
-        var timepoint;
         var colorVis 
         var satVal;
         var intention;
         var initSatVal;
 
+        // Shows .satvalue automatically
         $('.satvalue').css("display", "");
         for (var i = 0; i < elements.length; i++) {
             curr = elements[i].findView(paper).model;
@@ -378,12 +377,14 @@ class EVO {
                 continue;
             }
 
-            // Sets satvalue/text to the initial sat value
+            // Sets satvalue/text to the initSatVal
             intention = curr.get('intention');
             initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair');
-            if (initSatVal === '(no value)') {
+
+            if (initSatVal === '(no value)') {// If there is no initSatVal
                 curr.attr('.satvalue/text', '');
-            } else {
+            }
+            else {
                 curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
             }
 
@@ -397,21 +398,20 @@ class EVO {
                 if (analysisResult.get('selected')){
                     if (EVO.sliderOption == 3){// If the option is states
                         // Resets the satvalue back
-                        timepoint = EVO.curTimePoint;
                         colorVis = analysisResult.get('colorVis');
-                        satVal = colorVis.intentionListColorVis[0].timePoints[timepoint];
+                        satVal = colorVis.intentionListColorVis[0].timePoints[EVO.curTimePoint];
                         curr.attr('.satvalue/text', satisfactionValuesDict[satVal].satValue);
                         EVO.displaySlider(true);
                     }
-                    else {
+                    else {// If it is % or time
                         $('.satvalue').css("display", "none");
                     }
                 }
-                else {
+                else {// If result is unselected
                     curr.attr({text: {fill: 'black',stroke:'none'}});
                 }
             }
-            else {
+            else {// If a config without results is selected
                 curr.attr({text: {fill: 'black',stroke:'none'}});
             }
         }
@@ -421,11 +421,11 @@ class EVO {
      * Makes slider dis/appear 
      */
      static displaySlider(isState){
-        if (isState){
+        if (isState) {// If the sliderOption is set at state
             $('#slider').css("display", "");
             $('#sliderValue').css("display", "");
         }
-        else {
+        else {// If the sliderOption is not set at state
             $('#slider').css("display", "none");
             $('#sliderValue').css("display", "none");
         }
@@ -513,9 +513,11 @@ class EVO {
         EVO.refresh(analysisResult);
 
     }
-
+    /**
+     * Refresh teh slider for when swtcihing between configs and results
+     */
     static refreshSlider(analysisResult) {
-        if (analysisResult == undefined) {
+        if (analysisResult == undefined) {// If switching to configs
             $('#modelingSlider').css("display", "");
             $('#analysisSlider').css("display", "none");
             if(EVO.sliderOption > 0) {
@@ -523,7 +525,7 @@ class EVO {
             }
             document.getElementById("colorReset").value = EVO.sliderOption;
         }
-        else {
+        else {// If switching to result
             $('#modelingSlider').css("display", "none");
             $('#analysisSlider').css("display", "");
             document.getElementById("colorResetAnalysis").value = EVO.sliderOption;

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -382,22 +382,40 @@ class EVO {
                 continue;
             }
             intention = elements[i].get('intention');
-            initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair'); 
+            initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair');
+            
+            // Shows the satvalue
+            $('.satvalue').css("display", "");
+
+            // If there is result
             if (analysisResult !== undefined) {
-                if (!analysisResult.get('isPathSim')) {   
-                    if (initSatVal === '(no value)') {
-                        curr.attr('.satvalue/text', '');
-                        curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal'}});
-                    }
-                    else {
+                
+                // If the result is selected 
+                if (analysisResult.get('selected')){
+
+                    if (this.sliderOption == 3){
                         curr = elements[i].findView(paper).model;
                         curr.attr({text: {fill: 'white',stroke:'none'}});
                     }
+
+                    else {
+                        // Sets the satvalue off
+                        $('.satvalue').css("display", "none");
+                    }
                 }
+
+                // If the result is not selected
                 else {
-                    curr = elements[i].findView(paper).model;
-                    curr.attr({text: {fill: 'white',stroke:'none'}});
+                    if (initSatVal === '(no value)'){
+                        curr.attr('.satvalue/text', '');
+                        curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal'}});
+                    }
                 }
+            }
+            // If there isn't result
+            else {
+                curr = elements[i].findView(paper).model;
+                curr.attr({text: {fill: 'white',stroke:'none'}});
             }
         }
     }

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -406,8 +406,8 @@ paper.on("link:options", function (cell) {
             if (selectResult !== undefined){
                 selectResult.set('selected', false);
             }
-            // Remove Slider
-            removeSlider();
+            // // Remove Slider
+            // removeSlider();
 
             // Reset to initial graph prior to analysis
             revertNodeValuesToInitial();
@@ -741,31 +741,31 @@ function setInteraction(interactionValue) {
 // TODO: Re-write with new models
 function revertNodeValuesToInitial() {
     console.log("TODO: Rewrite revertNodeValuesToInitial");
-    // var elements = graph.getElements();
-    // var curr;
-    // for (var i = 0; i < elements.length; i++) {
-    // 	curr = elements[i].findView(paper).model;
+    var elements = graph.getElements();
+    var curr;
+    for (var i = 0; i < elements.length; i++) {
+    	curr = elements[i].findView(paper).model;
 
-    // 	if (curr.attributes.type !== 'basic.Goal' &&
-    // 		curr.attributes.type !== 'basic.Task' &&
-    // 		curr.attributes.type !== 'basic.Softgoal' &&
-    // 		curr.attributes.type !== 'basic.Resource') {
-    // 		continue;
-    // 	}     
-    // 	var intention = curr.get('intention');
-    //     var initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair'); 
+    	if (curr.get('type') !== 'basic.Goal' &&
+    		curr.get('type') !== 'basic.Task' &&
+    		curr.get('type') !== 'basic.Softgoal' &&
+    		curr.get('type') !== 'basic.Resource') {
+    		continue;
+    	}     
+    	var intention = curr.get('intention');
+        var initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair'); 
 
-    // 	if (initSatVal === '(no value)') {
-    //         curr.attr('.satvalue/text', '');
+    	if (initSatVal === '(no value)') {
+            curr.attr('.satvalue/text', '');
 
-    // 	} else {
-    //         curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
-    // 	}
-    //     //curr.attr({text: {fill: 'black'}});
-    //     curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal','font-size': 10}});
-    // }
-    // // Remove slider
-    // removeSlider();
+    	} else {
+            curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
+    	}
+        //curr.attr({text: {fill: 'black'}});
+        curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal','font-size': 10}});
+    }
+    // Remove slider
+    removeSlider();
 }
 
 /**

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -406,8 +406,6 @@ paper.on("link:options", function (cell) {
             if (selectResult !== undefined){
                 selectResult.set('selected', false);
             }
-            // // Remove Slider
-            // removeSlider();
 
             // Reset to initial graph prior to analysis
             revertNodeValuesToInitial();

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -383,6 +383,9 @@ paper.on("link:options", function (cell) {
         $('.link-tools .tool-options').css("display", "none");
         $('.attribution').css("display", "none");
         $('.inspector').css("display", "none");
+
+        EVO.refresh(selectResult);
+
         var configResults = configCollection.findWhere({ selected: true }).get('results');
         if (configResults !== undefined){
             selectResult = configResults.findWhere({ selected: true });
@@ -406,8 +409,10 @@ paper.on("link:options", function (cell) {
             if (selectResult !== undefined){
                 selectResult.set('selected', false);
             }
+
             // Remove Slider
             removeSlider();
+
             // Reset to initial graph prior to analysis
             revertNodeValuesToInitial();
 
@@ -555,7 +560,7 @@ paper.on("link:options", function (cell) {
             var fileName = name + ".json";
             var obj = {graph: graph.toJSON()}; // Same structure as the other two save options
             download(fileName, JSON.stringify(obj));
-            IntentionColoring.refresh(selectResult);
+            EVO.refresh(selectResult);
         }
     });
 
@@ -578,21 +583,21 @@ paper.on("link:options", function (cell) {
                 //elementInspector.$('.function-type').val('(no value)');
             }
         }
-        IntentionColoring.refresh(selectResult);
+        EVO.refresh(selectResult);
     });
 
     $('#colorblind-mode-isOff').on('click', function () { //activates colorblind mode
         $('#colorblind-mode-isOff').css("display", "none");
         $('#colorblind-mode-isOn').css("display", "");
 
-        IntentionColoring.toggleColorBlindMode(true, selectResult);
+        EVO.toggleColorBlindMode(true, selectResult);
     });
 
     $('#colorblind-mode-isOn').on('click', function () { //turns off colorblind mode
         $('#colorblind-mode-isOn').css("display", "none");
         $('#colorblind-mode-isOff').css("display", "");
 
-        IntentionColoring.toggleColorBlindMode(false, selectResult);
+        EVO.toggleColorBlindMode(false, selectResult);
     });
 
     /**
@@ -737,34 +742,30 @@ function setInteraction(interactionValue) {
  * Sets each node/cellview in the paper to its initial 
  * satisfaction value and colours all text to black
  */
-// TODO: Re-write with new models
 function revertNodeValuesToInitial() {
-    console.log("TODO: Rewrite revertNodeValuesToInitial");
-    // var elements = graph.getElements();
-    // var curr;
-    // for (var i = 0; i < elements.length; i++) {
-    // 	curr = elements[i].findView(paper).model;
+    var elements = graph.getElements();
+    var curr;
+    for (var i = 0; i < elements.length; i++) {
+    	curr = elements[i].findView(paper).model;
+    	if (curr.get('type') !== 'basic.Goal' &&
+            curr.get('type') !== 'basic.Task' &&
+    		curr.get('type') !== 'basic.Softgoal' &&
+    		curr.get('type') !== 'basic.Resource') {
+    		continue;
+    	}     
+    	var intention = curr.get('intention');
+        var initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair'); 
 
-    // 	if (curr.attributes.type !== 'basic.Goal' &&
-    // 		curr.attributes.type !== 'basic.Task' &&
-    // 		curr.attributes.type !== 'basic.Softgoal' &&
-    // 		curr.attributes.type !== 'basic.Resource') {
-    // 		continue;
-    // 	}     
-    // 	var intention = curr.get('intention');
-    //     var initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair'); 
+    	if (initSatVal === '(no value)') {
+            curr.attr('.satvalue/text', '');
 
-    // 	if (initSatVal === '(no value)') {
-    //         curr.attr('.satvalue/text', '');
-
-    // 	} else {
-    //         curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
-    // 	}
-    //     //curr.attr({text: {fill: 'black'}});
-    //     curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal','font-size': 10}});
-    // }
-    // // Remove slider
-    // removeSlider();
+    	} else {
+            curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
+    	}
+        curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal','font-size': 10}});
+    }
+    // Remove slider
+    removeSlider();
 }
 
 /**

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -383,11 +383,11 @@ paper.on("link:options", function (cell) {
         $('.link-tools .tool-options').css("display", "none");
         $('.attribution').css("display", "none");
         $('.inspector').css("display", "none");
-        IntentionColoring.refresh(selectResult);
         var configResults = configCollection.findWhere({ selected: true }).get('results');
         if (configResults !== undefined){
             selectResult = configResults.findWhere({ selected: true });
         }
+        IntentionColoring.refresh(selectResult);
 
         // TODO: Add check for model changes to potentially clear configCollection back in
     }

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -390,7 +390,7 @@ paper.on("link:options", function (cell) {
         if (configResults !== undefined){
             selectResult = configResults.findWhere({ selected: true });
         }
-        IntentionColoring.refresh(selectResult);
+        EVO.refresh(selectResult);
 
         // TODO: Add check for model changes to potentially clear configCollection back in
     }
@@ -540,8 +540,9 @@ paper.on("link:options", function (cell) {
     }
 
     $(window).resize(function () {
-        var configResults = configCollection.findWhere({ selected: true }).get('results').findWhere({ selected: true });
-        if (configResults !== undefined){
+        var config = configCollection.findWhere({ selected: true });
+        if (config !== undefined){
+            var configResults = config.get('results').findWhere({ selected: true });
             resizeWindow(configResults.get('timePointPath').length - 1);
         } 
     });

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -406,7 +406,8 @@ paper.on("link:options", function (cell) {
             if (selectResult !== undefined){
                 selectResult.set('selected', false);
             }
-
+            // Remove Slider
+            removeSlider();
             // Reset to initial graph prior to analysis
             revertNodeValuesToInitial();
 
@@ -739,31 +740,31 @@ function setInteraction(interactionValue) {
 // TODO: Re-write with new models
 function revertNodeValuesToInitial() {
     console.log("TODO: Rewrite revertNodeValuesToInitial");
-    var elements = graph.getElements();
-    var curr;
-    for (var i = 0; i < elements.length; i++) {
-    	curr = elements[i].findView(paper).model;
+    // var elements = graph.getElements();
+    // var curr;
+    // for (var i = 0; i < elements.length; i++) {
+    // 	curr = elements[i].findView(paper).model;
 
-    	if (curr.get('type') !== 'basic.Goal' &&
-    		curr.get('type') !== 'basic.Task' &&
-    		curr.get('type') !== 'basic.Softgoal' &&
-    		curr.get('type') !== 'basic.Resource') {
-    		continue;
-    	}     
-    	var intention = curr.get('intention');
-        var initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair'); 
+    // 	if (curr.attributes.type !== 'basic.Goal' &&
+    // 		curr.attributes.type !== 'basic.Task' &&
+    // 		curr.attributes.type !== 'basic.Softgoal' &&
+    // 		curr.attributes.type !== 'basic.Resource') {
+    // 		continue;
+    // 	}     
+    // 	var intention = curr.get('intention');
+    //     var initSatVal = intention.getUserEvaluationBBM(0).get('assignedEvidencePair'); 
 
-    	if (initSatVal === '(no value)') {
-            curr.attr('.satvalue/text', '');
+    // 	if (initSatVal === '(no value)') {
+    //         curr.attr('.satvalue/text', '');
 
-    	} else {
-            curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
-    	}
-        //curr.attr({text: {fill: 'black'}});
-        curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal','font-size': 10}});
-    }
-    // Remove slider
-    removeSlider();
+    // 	} else {
+    //         curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
+    // 	}
+    //     //curr.attr({text: {fill: 'black'}});
+    //     curr.attr({text: {fill: 'black',stroke:'none','font-weight' : 'normal','font-size': 10}});
+    // }
+    // // Remove slider
+    // removeSlider();
 }
 
 /**

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -142,6 +142,7 @@ var Config = Backbone.View.extend({
         this.$('.analysis-configuration').append(this.innerView.$el);
         if (this.model.get('selected')) {
             this.showAnalysisInspector();
+            this.resetAnalysis();
         }
         return this;
     },
@@ -201,9 +202,6 @@ var Config = Backbone.View.extend({
      * Sets selected value to true and triggers a switchConfig event to update highlight
      */
     switchConfig: function () {
-        $('#modelingSlider').css("display", "");
-        $('#analysisSlider').css("display", "none");
-        IntentionColoring.refresh(undefined)
         this.model.set({ selected: true });
         removeSlider();
     },
@@ -220,6 +218,13 @@ var Config = Backbone.View.extend({
         analysisInspector.render();
     },
 
+    resetAnalysis: function () {
+        // Removes the slider and  analysisSlider
+        $('#modelingSlider').css("display", "");
+        $('#analysisSlider').css("display", "none");
+        removeSlider();
+        IntentionColoring.refresh(undefined);
+    },
     /**
      * Hide/Show results dropdown 
      */

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -44,7 +44,7 @@ var ResultView = Backbone.View.extend({
         this.model.trigger('change:switchResults', this.model);
         this.config.set('selected', true);
         this.config.trigger('change:switchConfigs', this.config);
-        displayAnalysis(this.model, true, "analysis");
+        displayAnalysis(this.model, true);
     },
 
     /**
@@ -203,7 +203,7 @@ var Config = Backbone.View.extend({
      */
     switchConfig: function () {
         this.model.set({ selected: true });
-        removeSlider();
+        this.resetAnalysis();
     },
 
     /**

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -142,7 +142,8 @@ var Config = Backbone.View.extend({
         this.$('.analysis-configuration').append(this.innerView.$el);
         if (this.model.get('selected')) {
             this.showAnalysisInspector();
-            this.resetAnalysis();
+            //this.resetAnalysis();
+            EVO.switchToModelingMode(undefined, false);
         }
         return this;
     },
@@ -203,7 +204,7 @@ var Config = Backbone.View.extend({
      */
     switchConfig: function () {
         this.model.set({ selected: true });
-        this.resetAnalysis();
+        EVO.switchToModelingMode(undefined, false);
     },
 
     /**
@@ -218,13 +219,6 @@ var Config = Backbone.View.extend({
         analysisInspector.render();
     },
 
-    resetAnalysis: function () {
-        // Removes the slider and  analysisSlider
-        $('#modelingSlider').css("display", "");
-        $('#analysisSlider').css("display", "none");
-        removeSlider();
-        EVO.refresh(undefined);
-    },
     /**
      * Hide/Show results dropdown 
      */

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -223,7 +223,7 @@ var Config = Backbone.View.extend({
         $('#modelingSlider').css("display", "");
         $('#analysisSlider').css("display", "none");
         removeSlider();
-        IntentionColoring.refresh(undefined);
+        EVO.refresh(undefined);
     },
     /**
      * Hide/Show results dropdown 

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -38,13 +38,12 @@ var ResultView = Backbone.View.extend({
      */
     // TODO: Update this function to pass the ResultBBM into displayAnalysis
     switchResult: function () {
-        $('#modelingSlider').css("display", "none");
-        $('#analysisSlider').css("display", "");
         this.model.set('selected', true);
         this.model.trigger('change:switchResults', this.model);
         this.config.set('selected', true);
         this.config.trigger('change:switchConfigs', this.config);
         displayAnalysis(this.model, true);
+        EVO.refreshSlider(this.model);
     },
 
     /**
@@ -142,7 +141,7 @@ var Config = Backbone.View.extend({
         this.$('.analysis-configuration').append(this.innerView.$el);
         if (this.model.get('selected')) {
             this.showAnalysisInspector();
-            EVO.switchToModelingMode(undefined, false);
+            EVO.refreshSlider(undefined);
         }
         return this;
     },
@@ -205,10 +204,9 @@ var Config = Backbone.View.extend({
 
         $('#modelingSlider').css("display", "");
         $('#analysisSlider').css("display", "none");
-        EVO.refresh(undefined);
-
         this.model.set({ selected: true });
-        EVO.switchToModelingMode(undefined, false);
+        EVO.refresh(undefined);
+        EVO.refreshSlider(undefined);
     },
 
     /**

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -142,7 +142,6 @@ var Config = Backbone.View.extend({
         this.$('.analysis-configuration').append(this.innerView.$el);
         if (this.model.get('selected')) {
             this.showAnalysisInspector();
-            //this.resetAnalysis();
             EVO.switchToModelingMode(undefined, false);
         }
         return this;

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -205,7 +205,6 @@ var Config = Backbone.View.extend({
         $('#modelingSlider').css("display", "");
         $('#analysisSlider').css("display", "none");
         this.model.set({ selected: true });
-        EVO.refresh(undefined);
         EVO.refreshSlider(undefined);
     },
 

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -202,6 +202,11 @@ var Config = Backbone.View.extend({
      * Sets selected value to true and triggers a switchConfig event to update highlight
      */
     switchConfig: function () {
+
+        $('#modelingSlider').css("display", "");
+        $('#analysisSlider').css("display", "none");
+        EVO.refresh(undefined);
+
         this.model.set({ selected: true });
         EVO.switchToModelingMode(undefined, false);
     },

--- a/leaf-ui/rappid-extensions/ElementInspector.js
+++ b/leaf-ui/rappid-extensions/ElementInspector.js
@@ -593,7 +593,6 @@ var ElementInspector = Backbone.View.extend({
      * and updateChartUserDefined.
      */
     updateCell: function () {
-        IntentionColoring.refresh(undefined);
         changeFont(current_font, paper);
         if (this.intention.get('evolvingFunction') != null) {
             if (this.intention.get('evolvingFunction').get('type') == 'NT') {
@@ -608,6 +607,7 @@ var ElementInspector = Backbone.View.extend({
         } else {
             this.model.attr('.satvalue/text', satisfactionValuesDict[this.intention.getUserEvaluationBBM(0).get('assignedEvidencePair')].satValue);
         }
+        IntentionColoring.refresh(undefined);
     },
 
     /**

--- a/leaf-ui/rappid-extensions/ElementInspector.js
+++ b/leaf-ui/rappid-extensions/ElementInspector.js
@@ -593,6 +593,9 @@ var ElementInspector = Backbone.View.extend({
      * and updateChartUserDefined.
      */
     updateCell: function () {
+
+        EVO.refresh(undefined);
+
         changeFont(current_font, paper);
         if (this.intention.get('evolvingFunction') != null) {
             if (this.intention.get('evolvingFunction').get('type') == 'NT') {

--- a/leaf-ui/rappid-extensions/ElementInspector.js
+++ b/leaf-ui/rappid-extensions/ElementInspector.js
@@ -593,7 +593,6 @@ var ElementInspector = Backbone.View.extend({
      * and updateChartUserDefined.
      */
     updateCell: function () {
-
         EVO.refresh(undefined);
 
         changeFont(current_font, paper);

--- a/leaf-ui/rappid-extensions/ElementInspector.js
+++ b/leaf-ui/rappid-extensions/ElementInspector.js
@@ -610,7 +610,6 @@ var ElementInspector = Backbone.View.extend({
         } else {
             this.model.attr('.satvalue/text', satisfactionValuesDict[this.intention.getUserEvaluationBBM(0).get('assignedEvidencePair')].satValue);
         }
-        IntentionColoring.refresh(undefined);
     },
 
     /**


### PR DESCRIPTION
This closes issue #221
- [x] Before, when switching back to off or modeling mode, the satvalue does not update to the initial sat val. Instead it is the last satvalue checked from the slider
- [x] Before, when simulating path, the slider would pop up for all EVO options. Now the slider shows only in state sliderOption
- [x] Before, the satvlaue showed up for both `%` and `time` sliderOption, now it does not
- [x] Before, the text color in modeling mode would not update back to black after simulating path
- [x] Before, when switching configs, the analysis slider would not update to modeling slider
- [x] Fixed issue with `revertNodeValuesToInitial()`