### PR TITLE
Resolved remaining CSS bugs

### DIFF
--- a/leaf-ui/css/style.css
+++ b/leaf-ui/css/style.css
@@ -119,9 +119,14 @@ body {
   bottom: 0;
   width: 200px;
   background-color: #f9f9f9;
-  box-shadow: 2px 0px 16px 0px rgba(0,0,0,0.2);
+  
   /* Should be less than the modal pop-ups */ 
   z-index: 0;
+}
+
+.left-panel.model-only{
+  bottom: 130px;
+  box-shadow: 2px 0px 16px 0px rgba(0,0,0,0.05);
 }
 
 .stencil {

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -587,7 +587,6 @@ paper.on("link:options", function (cell) {
         $('.link-tools .tool-remove').css("display", "none");
         $('.link-tools .tool-options').css("display", "none");
         $('.attribution').css("display", "none");
-        $('.inspector').css("display", "none");
 
         EVO.refresh(selectResult);
 


### PR DESCRIPTION
- changed stencil scroll box to stop above the watermark/attribution box, so attribution doesn't overlap stencil elements
- investigated auto-scrolling to where new results are added; decided this would be overcomplicated
- verified that other listed bugs appear to be fixed