### PR TITLE
Dragging actor under intentions, and removing mentions of configurations

### DIFF
--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -33,8 +33,8 @@
             <div class="dropdown-toolbar">
                 <a id="btn-load" class="model-only">Load</a>
                 <a id="btn-save">Save Model</a>
-                <a id="btn-save-analysis">Save Model and Analysis Configuration</a>
-                <a id="btn-save-all">Save Model, Analysis Configuration, and Results</a>
+                <a id="btn-save-analysis">Save Model and Analysis Requests</a>
+                <a id="btn-save-all">Save Model, Analysis Requests, and Results</a>
                 <a id="btn-svg">Open as SVG</a>
             </div>
         </div>
@@ -49,7 +49,7 @@
                 <a id="btn-clear-flabel" class='model-only'>Clear Dynamic Function Labels</a>
                 <a id="btn-clear-cycle" class='model-only'>Clear Cycle Highlighting</a>
                 <a id="btn-clear-results" class='analysis-only' style="display: none;">Clear Results Only</a>
-                <a id="btn-clear-analysis" class='analysis-only' style="display: none;">Clear Configurations and
+                <a id="btn-clear-analysis" class='analysis-only' style="display: none;">Clear Requests and
                     Results</a>
             </div>
         </div>

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -303,11 +303,6 @@ graph.on("change", function () {
     document.cookie = "graph=" + graphtext;
 });
 
-graph.on('change:size', function (cell, size) {
-    cell.attr(".label/cx", 0.1 * size.width);
-});
-
-
 graph.on('remove', function (cell) {
     // Clear right inspector side panel
     clearInspector();

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -304,14 +304,7 @@ graph.on("change", function () {
 });
 
 graph.on('change:size', function (cell, size) {
-    cell.attr(".label/cx", 0.25 * size.width);
-
-    // Calculate point on actor boundary for label (to always remain on boundary)
-    var b = size.height;
-    var c = -(size.height / 2 + (size.height / 2) * (size.height / 2) * (1 - (-0.75 * size.width / 2) * (-0.75 * size.width / 2) / ((size.width / 2) * (size.width / 2))));
-    var y_cord = (-b + Math.sqrt(b * b - 4 * c)) / 2;
-
-    cell.attr(".label/cy", y_cord);
+    cell.attr(".label/cx", 0.1 * size.width);
 });
 
 
@@ -423,7 +416,6 @@ paper.on({
                     if (evt.data.move) {
                         // AND actor doesn't overlap with other actors
                         var overlapCells = paper.findViewsInArea(cell.getBBox());
-                        console.log(overlapCells);
                         var overlapActors = overlapCells.filter(view => view.model instanceof joint.shapes.basic.Actor);
                         if (overlapActors.length == 1){
                             // Embed each overlapping intention in actor

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -421,12 +421,9 @@ paper.on({
                             // Embed each overlapping intention in actor
                             var actorCell = overlapActors[0].model;
                             var overlapIntentions = overlapCells.filter(view => view.model instanceof joint.shapes.basic.Intention);
-                            console.log("overlap intentions:");
-                            console.log(overlapIntentions);
 
                             for (var i=0; i < overlapIntentions.length; i++) {
                                 var intention = overlapIntentions[i].model;
-                                console.log(intention);
                                 // Unembed intention from old actor
                                 if (intention.get('parent')) {
                                     graph.getCell(intention.get('parent')).unembed(intention);
@@ -449,7 +446,6 @@ paper.on({
                         
                         // Find overlapping cells
                         var overlapCells = paper.findViewsFromPoint(cell.getBBox().center());
-                        console.log(overlapCells);
 
                         // Find actors which overlap with cell
                         // Embed element in new actor

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -422,7 +422,7 @@ paper.on({
                     // If user was dragging actor 
                     if (evt.data.move) {
                         // AND actor doesn't overlap with other actors
-                        var overlapCells = paper.findViewsFromPoint(cell.getBBox().center());
+                        var overlapCells = paper.findViewsInArea(cell.getBBox());
                         console.log(overlapCells);
                         var overlapActors = overlapCells.filter(view => view.model instanceof joint.shapes.basic.Actor);
                         if (overlapActors.length == 1){

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -419,6 +419,31 @@ paper.on({
                     var actorInspector = new ActorInspector({ model: cell });
                     $('.inspector').append(actorInspector.el);
                     actorInspector.render();
+                    // If user was dragging actor 
+                    if (evt.data.move) {
+                        // AND actor doesn't overlap with other actors
+                        var overlapCells = paper.findViewsFromPoint(cell.getBBox().center());
+                        console.log(overlapCells);
+                        var overlapActors = overlapCells.filter(view => view.model instanceof joint.shapes.basic.Actor);
+                        if (overlapActors.length == 1){
+                            // Embed each overlapping intention in actor
+                            var actorCell = overlapActors[0].model;
+                            var overlapIntentions = overlapCells.filter(view => view.model instanceof joint.shapes.basic.Intention);
+                            console.log("overlap intentions:");
+                            console.log(overlapIntentions);
+
+                            for (var i=0; i < overlapIntentions.length; i++) {
+                                var intention = overlapIntentions[i].model;
+                                console.log(intention);
+                                // Unembed intention from old actor
+                                if (intention.get('parent')) {
+                                    graph.getCell(intention.get('parent')).unembed(intention);
+                                }
+                                // Embed intention in new actor
+                                actorCell.embed(intention);
+                            }
+                        }
+                    }
                 } else {
                     var elementInspector = new ElementInspector({ model: cell });
                     $('.inspector').append(elementInspector.el);
@@ -429,10 +454,13 @@ paper.on({
                         if (cell.get('parent')) {
                             graph.getCell(cell.get('parent')).unembed(cell);
                         }
-                        // Embed element in new actor
+                        
+                        // Find overlapping cells
                         var overlapCells = paper.findViewsFromPoint(cell.getBBox().center());
+                        console.log(overlapCells);
 
                         // Find actors which overlap with cell
+                        // Embed element in new actor
                         overlapCells = overlapCells.filter(view => view.model instanceof joint.shapes.basic.Actor);
                         if (overlapCells.length > 0) {
                             var actorCell = overlapCells[0].model;
@@ -874,7 +902,6 @@ function clearInspector() {
         $('.inspector-views').trigger('clearInspector');
     }
 }
-
 
 /**
  * Returns true iff node has 1 or more NBT or NBD relationship

--- a/leaf-ui/rappid-extensions/joint.extensions.js
+++ b/leaf-ui/rappid-extensions/joint.extensions.js
@@ -241,7 +241,7 @@ joint.shapes.basic.CellLink = joint.dia.Link.extend({
 
 
 joint.shapes.basic.Actor = joint.shapes.basic.Generic.extend({
-    markup: '<g class="scalable"><circle class = "outer"/></g><circle class="label"/><path class="line"/><text class = "name"/>',
+    markup: '<g class="scalable"><rect class = "outer"/></g><circle class="label"/><path class="line"/><text class = "name"/>',
 
     defaults: joint.util.deepSupplement({
         type: "basic.Actor",
@@ -258,9 +258,10 @@ joint.shapes.basic.Actor = joint.shapes.basic.Generic.extend({
                 stroke: '#000000'
             },
             ".outer": {
-                r: 60,
-                cx: 60,
-                cy: 60,
+                width: 100,
+                height: 60,
+                rx: 20,
+                ry: 20,
                 fill: '#EBFFEA', //'#CCFFCC',
                 stroke: '#000000',
                 'stroke-dasharray': '5 2'

--- a/leaf-ui/rappid-extensions/joint.extensions.js
+++ b/leaf-ui/rappid-extensions/joint.extensions.js
@@ -252,16 +252,16 @@ joint.shapes.basic.Actor = joint.shapes.basic.Generic.extend({
         attrs: {
             ".label": {
                 r: 30,
-                cx: 30,
-                cy: 30,
+                cx: 20,
+                cy: 20,
                 fill: '#FFFFA4',
                 stroke: '#000000'
             },
             ".outer": {
                 width: 100,
                 height: 60,
-                rx: 20,
-                ry: 20,
+                rx: 10,
+                ry: 10,
                 fill: '#EBFFEA', //'#CCFFCC',
                 stroke: '#000000',
                 'stroke-dasharray': '5 2'


### PR DESCRIPTION
Resolves issue 577 (replace mentions of Configuration with Request in the frontend), and makes progress towards resolving issue 345. Moving an actor under an intention will now add the intention to the actor - but only as long as the intention aligns with the the center of the actor. We still need to find a way to add the intention to the actor if it's not perfectly aligned with the actor's center.