### PR TITLE
Updated load-save to incorporate older models of BloomingLeaf

### DIFF
--- a/leaf-analysis/app.js
+++ b/leaf-analysis/app.js
@@ -4,7 +4,7 @@
 
 // Name of .jar file for BloomingLeaf project must be Blooming.jar
 //var userPath = "/Users/<your user path here>/BloomingLeaf"
-var userPath = "/Users/judySmith/git/BloomingLeaf"
+var userPath = "C:/GitHub/BloomingLeaf"
 
 var http = require('http'),
     url = require('url'),

--- a/leaf-analysis/app.js
+++ b/leaf-analysis/app.js
@@ -4,7 +4,7 @@
 
 // Name of .jar file for BloomingLeaf project must be Blooming.jar
 //var userPath = "/Users/<your user path here>/BloomingLeaf"
-var userPath = "C:/GitHub/BloomingLeaf"
+var userPath = "/Users/judySmith/git/BloomingLeaf"
 
 var http = require('http'),
     url = require('url'),

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -71,13 +71,14 @@ function loadOldVersion(obj) {
 		cell = cells[i];
 		if (cell.get('type') == "basic.Actor") {
 			loadOldActor(cell) //Create actor
-		} else if (cell.get('type') == "link") {
+		} else if (cell.get('type') == "basic.CellLink") {
 			loadOldLinks(cell, obj.model.links) //Create link
 		} else {
 			// Singled out functionSegList from obj as it doesn't show up in the graph after reading from JSON
 			loadOldElement(cell, obj.model.intentions, obj.model.constraints) //Create element
 		}
 	}
+	//changeLinkType()
 }
 
 /**
@@ -97,6 +98,18 @@ function getConstArr(arr) {
 		res.push(constraint);
 	}
 	return res;
+}
+*/
+
+function changeLinkType() {
+	cellPaper = document.getElementsByClassName('joint-type-link');
+	for (var i = 0; i < cellPaper.length; i++) {
+		console.log(cellPaper[i].className.baseVal)
+		cellPaper[i].className.baseVal = "joint-cell joint-type-basic joint-type-basic-celllink joint-link joint-theme-default"
+		cellPaper[i].className.animVal = "joint-cell joint-type-basic joint-type-basic-celllink joint-link joint-theme-default"
+		cellPaper[i].dataset.type = 'basic.CellLink'
+		console.log(cellPaper[i].dataset.type)
+	}
 }
 
 /**
@@ -151,6 +164,8 @@ function loadOldLinks(cell, arr) {
 
 	var linkBBM = new LinkBBM({ displayType: oldDisplayType, linkType: oldLinkType, postType: oldPostType, absTime: oldLink.absoluteValue, evolving: oldEvolving }); 
 	cell.set('link', linkBBM);
+	cell.set('type', 'basic.CellLink')
+	
 }
 
 /**
@@ -243,6 +258,7 @@ function createBBActor(cell) {
 	var actor = cell.get('actor');
 	var actorBBM = new ActorBBM({ type: actor.attributes.type, actorName: actor.attributes.actorName });
 	cell.set('actor', actorBBM)
+	cell.attr({'.label': {'cx': 20, 'cy' : 20}})
 }
 
 /**

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -34,8 +34,8 @@ reader.onload = function () {
 		loadOldVersion(result)
 	}
 	
-	//var graphtext = JSON.stringify(graph.toJSON());
-	//document.cookie = "graph=" + graphtext;
+	var graphtext = JSON.stringify(graph.toJSON());
+	document.cookie = "graph=" + graphtext;
 }
 
 /**
@@ -82,9 +82,9 @@ function loadOldVersion(obj) {
 			loadOldElement(cell, obj.model.intentions, obj.model.constraints, obj.analysisRequest.userAssignmentsList); 
 		}
 	}
-	// TODO: determine if Config needs to be modified as well
+	graph.set("maxAbsTime", obj.model.maxAbsTime);
+	loadOldConfig(obj.analysisRequest)
 }
-
 /**
  * Load the old actors into ActorBBM
  */
@@ -119,8 +119,11 @@ function loadOldLinks(cell, arr) {
 			var oldLink = arr[i];
 			if (oldLink.postType != null) {
 				oldEvolving = true; 
-				var oldPostType = oldLink.postType.toLowerCase();
-			 }else {
+				var oldPostType = oldLink.postType;
+				if ((oldPostType == 'AND') || (oldPostType == 'OR') || (oldPostType == 'NO')) {
+					oldPostType = oldLink.postType.toLowerCase();
+				}
+			 } else {
 				 oldEvolving = false;
 				}
 		}
@@ -128,7 +131,7 @@ function loadOldLinks(cell, arr) {
 
 	var oldLinkType = oldLink.linkType;
 	// Modify the linktypes into formats that the current Linkinspector recognizes
-	if (!((oldLinkType == 'NBT') || (oldLinkType == 'NBD'))){
+	if ((oldLinkType == 'AND') || (oldLinkType == 'OR') || (oldLinkType == 'NO')){
 		oldLinkType = oldLinkType.toLowerCase();
 		if (oldLinkType == 'no') {
 			cell.label(0, { position: 0.5, attrs: { text: { text: 'no' } } });
@@ -140,6 +143,7 @@ function loadOldLinks(cell, arr) {
 	// Reassign linkBBM to cell
 	var linkBBM = new LinkBBM({ displayType: oldDisplayType, linkType: oldLinkType, postType: oldPostType, absTime: oldLink.absoluteValue, evolving: oldEvolving }); 
 	cell.set('link', linkBBM);
+	console.log(linkBBM)
 }
 
 /**
@@ -164,7 +168,7 @@ function loadOldElement(cell, oldElements, constraintList, userAssignmentsList) 
 			oldConstraints.push(constraintList[i]); 
 		}
 	}
-
+	// Find the old userevaluation information
 	for ( var i = 0; i < userAssignmentsList.length; i++) {
 		if (cell.get('nodeID') == userAssignmentsList[i].intentionID){
 			oldUserEval = userAssignmentsList[i];

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -68,6 +68,12 @@ function loadFromObject(obj) {
 	}
 }
 
+/** 
+ * Loads old version of object obj by creating an actor, link, or element.
+ * Updates maxAbsTime of old version.
+ * 
+ * @param {Object} obj 
+ */
 function loadOldVersion(obj) {
 	graph.fromJSON(obj.graph);
 	var cells = graph.getCells();
@@ -85,6 +91,7 @@ function loadOldVersion(obj) {
 	graph.set("maxAbsTime", obj.model.maxAbsTime);
 	loadOldConfig(obj.analysisRequest)
 }
+
 /**
  * Load the old actors into ActorBBM
  */

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -22,7 +22,6 @@ reader.onload = function () {
 		return;
 	}
 	clearInspector();
-	console.log(reader);
 	var result = JSON.parse(reader.result);
 	if ( result.graph.type != undefined) { // TODO: find a better way to distinguish the different versions
 		loadFromObject(result);
@@ -31,7 +30,6 @@ reader.onload = function () {
 		// This can't be done with the current version as there is a link parameter
 		var text = reader.result.replaceAll('"link"', '"basic.CellLink"')
 		result = JSON.parse(text); // Reread the file
-		console.log(result)
 		loadOldVersion(result)
 	}
 	
@@ -151,7 +149,6 @@ function loadOldLinks(cell, arr) {
 	// Reassign linkBBM to cell
 	var linkBBM = new LinkBBM({ displayType: oldDisplayType, linkType: oldLinkType, postType: oldPostType, absTime: oldLink.absoluteValue, evolving: oldEvolving }); 
 	cell.set('link', linkBBM);
-	console.log(linkBBM)
 }
 
 /**

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -26,8 +26,11 @@ reader.onload = function () {
 	if ( result.graph.type != undefined) { // TODO: find a better way to distinguish the different versions
 		loadFromObject(result);
 	} else {
+		// Replace the "link" in the type parameter with basic.CellLink so that the cell is later on read correctly as a link rather than element
+		// This can't be done with the current version as there is a link parameter
 		var text = reader.result.replaceAll('"link"', '"basic.CellLink"')
-		result = JSON.parse(text);
+		result = JSON.parse(text); // Reread the file
+		console.log(result)
 		loadOldVersion(result)
 	}
 	
@@ -54,7 +57,6 @@ function loadFromObject(obj) {
 			createBBLink(cell) //Create link
 		} else {
 			// Singled out functionSegList from obj as it doesn't show up in the graph after reading from JSON
-			// var funcseg = obj.graph.cells[i].intention.attributes.evolvingFunction.attributes.functionSegList;
 			var funcseg = cell.attributes.intention.attributes.evolvingFunction.attributes.functionSegList;
 			createBBElement(cell, funcseg) //Create element
 		}
@@ -72,42 +74,24 @@ function loadOldVersion(obj) {
 	for (var i = 0; i < cells.length; i++) {
 		cell = cells[i];
 		if (cell.get('type') == "basic.Actor") {
-			loadOldActor(cell) //Create actor
+			loadOldActor(cell); // Create actor
 		} else if (cell.get('type') == "basic.CellLink") {
-			loadOldLinks(cell, obj.model.links) //Create link
+			loadOldLinks(cell, obj.model.links); // Create link, need to pass in the array of links to find the link types
 		} else {
-			// Singled out functionSegList from obj as it doesn't show up in the graph after reading from JSON
-			loadOldElement(cell, obj.model.intentions, obj.model.constraints) //Create element
+			// Create element by passing in the cell, the intentions that have the types, and the constraints
+			loadOldElement(cell, obj.model.intentions, obj.model.constraints, obj.analysisRequest.userAssignmentsList); 
 		}
 	}
+	// TODO: determine if Config needs to be modified as well
 }
-
-/**
- * Returns an array of Constraint objects with information from 
- * arr
- *
- * @param {Array.<Object>} arr
- * @returns {Array.<Constraint>}
- */
-/*
-function getConstArr(arr) {
-	var res = [];
-
-	for (var i = 0; i < arr.length; i++) {
-		var constraint = Object.assign(new Constraint, arr[i]);
-		constraint.absoluteValue = arr[i].absoluteValue;
-		res.push(constraint);
-	}
-	return res;
-}
-*/
 
 /**
  * Load the old actors into ActorBBM
  */
 function loadOldActor(cell) {
+	// Doesn't have other actors bc previous version had a bug where actor types can't be changed
 	var actorBBM = new ActorBBM({ type: 'basic.Actor', actorName: cell.attr(".name/text")});
-	cell.attr({'.label': {'cx': 20, 'cy' : 20}})
+	cell.attr({'.label': {'cx': 20, 'cy' : 20}}) // Adjust the labels to fit the round actors
 	cell.set('actor', actorBBM)
 }
 
@@ -120,15 +104,16 @@ function loadOldLinks(cell, arr) {
 	var oldDisplayType;
 	var oldEvolving;
 
-    if (((source === 'basic.Actor') && (target !== 'basic.Actor')) || ((source !== 'basic.Actor') && (target === 'basic.Actor'))) {
+	// Find the display type
+    if (((source === 'basic.Actor') && (target !== 'basic.Actor')) || ((source !== 'basic.Actor') && (target === 'basic.Actor'))) { // If the link is between an intention and an actor
         oldDisplayType = 'error';
     } else if (source === "basic.Actor") {
         oldDisplayType = 'Actor';
     } else {
-        oldDisplayType = 'element'; //TODO: Should this be set to 'link'?
+        oldDisplayType = 'element'; 
     }
 
-
+	// Find the link type and whether it was an evolving link and has post type
 	for (var i = 0; i < arr.length; i++) {
 		if (cell.get('linkID') == arr[i].linkID){
 			var oldLink = arr[i];
@@ -142,6 +127,7 @@ function loadOldLinks(cell, arr) {
 	}
 
 	var oldLinkType = oldLink.linkType;
+	// Modify the linktypes into formats that the current Linkinspector recognizes
 	if (!((oldLinkType == 'NBT') || (oldLinkType == 'NBD'))){
 		oldLinkType = oldLinkType.toLowerCase();
 		if (oldLinkType == 'no') {
@@ -151,54 +137,68 @@ function loadOldLinks(cell, arr) {
 		cell.label(0, { position: 0.5, attrs: { text: { text: oldLinkType } } });
 	}
 	
-
+	// Reassign linkBBM to cell
 	var linkBBM = new LinkBBM({ displayType: oldDisplayType, linkType: oldLinkType, postType: oldPostType, absTime: oldLink.absoluteValue, evolving: oldEvolving }); 
 	cell.set('link', linkBBM);
 }
 
 /**
-* Loads old elements into BB Models
+* Loads old elements into BBM Models
 *
 */
-function loadOldElement(cell, oldElements, constraintList ) {
+function loadOldElement(cell, oldElements, constraintList, userAssignmentsList) {
 	var oldElement;
+	var oldUserEval;
 	var oldConstraints = [];
 
 	for (var i = 0; i < oldElements.length; i++) {
+		// Find the old intention information
 		if (cell.get('nodeID') == oldElements[i].nodeID){
 			oldElement = oldElements[i];
 		}
 	}
 
+	// Find all the constraints relate with the intention
 	for (var i = 0; i < constraintList.length; i++) {
 		if (cell.get('nodeID') == constraintList[i].constraintSrcID){
-			oldConstraints.push(constraintList[i]); // TODO: make sure it incorporates multiple constraints later 
+			oldConstraints.push(constraintList[i]); 
 		}
 	}
+
+	for ( var i = 0; i < userAssignmentsList.length; i++) {
+		if (cell.get('nodeID') == userAssignmentsList[i].intentionID){
+			oldUserEval = userAssignmentsList[i];
+		}
+	}
+
+	// Create the new intentionBBM after getting the evolvingFunction
 	var intentionBBM = new IntentionBBM({ nodeName: oldElement.nodeName, evolvingFunction: getOldEvolvingFunction(oldElement, oldConstraints) });
-	
-	intentionBBM.get('userEvaluationList').push(new UserEvaluationBBM({}));
+	 // Create userEvaluationBBM for intentionBBM
+	intentionBBM.get('userEvaluationList').push(new UserEvaluationBBM({assignedEvidencePair: oldUserEval.evaluationValue, absTime: oldUserEval.absTime}));
 
 	cell.set('intention', intentionBBM);
 }
 
 
 /**
-* Given an object containing information about an EvolvingFunction,
-* returns a corresponding EvolvingFunction object
-* TODO: Determine how necessary this function is
-* @param {Object} obj
+* Given an object containing information about the old EvolvingFunction 
+* and an array of associated constraints,
+* returns a corresponding EvolvingFunction BBM
+* 
+* @param {Object} obj @param {Array.<Object>} oldConstraint
 * @returns {EvolvingFunction}
 */
 function getOldEvolvingFunction(obj, oldConstraint) {
-	var evolving
+	var evolving;
 	if (obj.dynamicFunction.functionSegList != undefined) {
+		// Get information on function segment list with its associated constraints 
 		var functionInfo = getFuncSegList(obj.dynamicFunction.functionSegList, oldConstraint);
 		evolving = new EvolvingFunctionBBM({ type: obj.dynamicFunction.stringDynVis, hasRepeat: functionInfo.hasRepeat, repStart: functionInfo.repStart, repStop: functionInfo.repStop, repCount: functionInfo.repCount, repAbsTime: functionInfo.repAbsTime, functionSegList: functionInfo.functionList });
 	} else {
 		evolving = new EvolvingFunctionBBM({});
 	}
-   
+	// Set repAbsTime here because somehow it doesn't get read if we intialize it
+    evolving.set('repAbsTime', functionInfo.repabsTime)
    return evolving;
 }
 
@@ -212,17 +212,19 @@ function getOldEvolvingFunction(obj, oldConstraint) {
 function getFuncSegList(functionseg, oldConstraints) {
 	var res = [];
 	res.functionList = [];
+	// Assume there is not repeats first
 	res.hasRepeat = false;
 	res.repStop = null;
 	res.repCount = null;
 	res.repabsTime = null;
 	var AT = null;
 	for (var i = 0; i < functionseg.length; i++) {
+		// If there is a repeated segment
 		if (functionseg[i].repNum) {
-			// If this segment is a repeating segment
 			res.hasRepeat = true;
-
+			// Get the repeated functionSegList
 			var repFuncSeg = functionseg[i].functionSegList;
+
 			res.repStart = repFuncSeg[0].funcStart;
 			for (var k = 0; k < repFuncSeg.length; k++) {
 				if (oldConstraints.length > 0) {
@@ -232,13 +234,12 @@ function getFuncSegList(functionseg, oldConstraints) {
 						}
 					}
 				}
-				res.functionList.push(new FunctionSegmentBBM({ type: repFuncSeg[k].funcType, refEvidencePair: repFuncSeg[k].funcX, startTP: repFuncSeg[k].funcStart, startAT: repFuncSeg[k].funcStart === constraint.constraintSrcEB ? constraint.absoluteValue : null, current: k == (repFuncSeg.length - 1) ? true : false }));
-				if (k == repFuncSeg.length-1) {
-					res.repStop = repFuncSeg[k].funcStop;
-				}
-				res.repCount = parseInt(functionseg[i].repNum);
-				res.repabsTime = parseInt(functionseg[i].absTime);
+				res.functionList.push(new FunctionSegmentBBM({ type: repFuncSeg[k].funcType, refEvidencePair: repFuncSeg[k].funcX, startTP: repFuncSeg[k].funcStart, startAT: AT, current: k == (repFuncSeg.length - 1) ? true : false }));
 			}
+			res.repStop = repFuncSeg[repFuncSeg.length-1].funcStop;
+			res.repCount = parseInt(functionseg[i].repNum);
+			res.repabsTime = parseInt(functionseg[i].absTime);
+
 		} else {
 			// If this segment is not a repeating segment
 			// startAT = start absolute time (int), startTP = start time point (string)

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -23,11 +23,9 @@ reader.onload = function () {
 	}
 	clearInspector();
 	var result = JSON.parse(reader.result);
-	if ( result.graph.type != undefined) { // TODO: find a better way to distinguish the different versions
+	if ( result.graph.type != undefined) {
 		loadFromObject(result);
 	} else {
-		var text = reader.result.replaceAll('"link"', '"basic.CellLink"')
-		result = JSON.parse(text);
 		loadOldVersion(result)
 	}
 	
@@ -80,6 +78,7 @@ function loadOldVersion(obj) {
 			loadOldElement(cell, obj.model.intentions, obj.model.constraints) //Create element
 		}
 	}
+	//changeLinkType()
 }
 
 /**
@@ -101,6 +100,17 @@ function getConstArr(arr) {
 	return res;
 }
 */
+
+function changeLinkType() {
+	cellPaper = document.getElementsByClassName('joint-type-link');
+	for (var i = 0; i < cellPaper.length; i++) {
+		console.log(cellPaper[i].className.baseVal)
+		cellPaper[i].className.baseVal = "joint-cell joint-type-basic joint-type-basic-celllink joint-link joint-theme-default"
+		cellPaper[i].className.animVal = "joint-cell joint-type-basic joint-type-basic-celllink joint-link joint-theme-default"
+		cellPaper[i].dataset.type = 'basic.CellLink'
+		console.log(cellPaper[i].dataset.type)
+	}
+}
 
 /**
  * Load the old actors into ActorBBM
@@ -154,28 +164,27 @@ function loadOldLinks(cell, arr) {
 
 	var linkBBM = new LinkBBM({ displayType: oldDisplayType, linkType: oldLinkType, postType: oldPostType, absTime: oldLink.absoluteValue, evolving: oldEvolving }); 
 	cell.set('link', linkBBM);
+	cell.set('type', 'basic.CellLink')
+	
 }
 
 /**
 * Loads old elements into BB Models
 *
 */
-function loadOldElement(cell, oldElements, constraintList ) {
-	var oldElement;
-	var oldConstraints = [];
-
+function loadOldElement(cell, oldElements, oldConstraints) {
 	for (var i = 0; i < oldElements.length; i++) {
 		if (cell.get('nodeID') == oldElements[i].nodeID){
-			oldElement = oldElements[i];
+			var oldElement = oldElements[i];
 		}
 	}
 
-	for (var i = 0; i < constraintList.length; i++) {
-		if (cell.get('nodeID') == constraintList[i].constraintSrcID){
-			oldConstraints.push(constraintList[i]); // TODO: make sure it incorporates multiple constraints later 
+	for (var i = 0; i < oldConstraints.length; i++) {
+		if (cell.get('nodeID') == oldConstraints[i].constraintSrcID){
+			var oldConstraint = oldConstraints[i];
 		}
 	}
-	var intentionBBM = new IntentionBBM({ nodeName: oldElement.nodeName, evolvingFunction: getOldEvolvingFunction(oldElement, oldConstraints) });
+	var intentionBBM = new IntentionBBM({ nodeName: oldElement.nodeName, evolvingFunction: getOldEvolvingFunction(oldElement, oldConstraint) });
 	
 	intentionBBM.get('userEvaluationList').push(new UserEvaluationBBM({}));
 
@@ -206,50 +215,34 @@ function getOldEvolvingFunction(obj, oldConstraint) {
 * Returns an array of FuncSegment or RepFuncSegment objects with 
 * information from arr
 *
-* @param {Array.<Object>} functionseg
+* @param {Array.<Object>} arr
 * @returns {Array.<FuncSegment|RepFuncSegment>}
 */
-function getFuncSegList(functionseg, oldConstraints) {
+function getFuncSegList(arr, constraint) {
 	var res = [];
 	res.functionList = [];
 	res.hasRepeat = false;
 	res.repStop = null;
 	res.repCount = null;
 	res.repabsTime = null;
-	var AT = null;
-	for (var i = 0; i < functionseg.length; i++) {
-		if (functionseg[i].repNum) {
+	for (var i = 0; i < arr.length; i++) {
+		if (arr[i].repNum) {
 			// If this segment is a repeating segment
 			res.hasRepeat = true;
 
-			var repFuncSeg = functionseg[i].functionSegList;
+			var repFuncSeg = arr[i].functionSegList;
 			res.repStart = repFuncSeg[0].funcStart;
 			for (var k = 0; k < repFuncSeg.length; k++) {
-				if (oldConstraints.length > 0) {
-					for (var j = 0; j < oldConstraints.length; j++) {
-						if (repFuncSeg[k].funcStart === oldConstraints[j].constraintSrcEB) {
-							AT =  oldConstraints[j].absoluteValue;
-						}
-					}
-				}
 				res.functionList.push(new FunctionSegmentBBM({ type: repFuncSeg[k].funcType, refEvidencePair: repFuncSeg[k].funcX, startTP: repFuncSeg[k].funcStart, startAT: repFuncSeg[k].funcStart === constraint.constraintSrcEB ? constraint.absoluteValue : null, current: k == (repFuncSeg.length - 1) ? true : false }));
 				if (k == repFuncSeg.length-1) {
 					res.repStop = repFuncSeg[k].funcStop;
 				}
-				res.repCount = parseInt(functionseg[i].repNum);
-				res.repabsTime = parseInt(functionseg[i].absTime);
+				res.repCount = parseInt(arr[i].repNum);
+				res.repabsTime = parseInt(arr[i].absTime);
 			}
 		} else {
 			// If this segment is not a repeating segment
-			// startAT = start absolute time (int), startTP = start time point (string)
-			if (oldConstraints.length > 0) {
-				for (var j = 0; j < oldConstraints.length; j++) {
-					if (functionseg[i].funcStart === oldConstraints[j].constraintSrcEB) {
-						AT =  oldConstraints[j].absoluteValue;
-					}
-				}
-			} 	
-			res.functionList.push(new FunctionSegmentBBM({ type: functionseg[i].funcType, refEvidencePair: functionseg[i].funcX, startTP: functionseg[i].funcStart, startAT: AT, current: i == (functionseg.length - 1) ? true : false }));
+			res.functionList.push(new FunctionSegmentBBM({ type: arr[i].funcType, refEvidencePair: arr[i].funcX, startTP: arr[i].funcStart, startAT: arr[i].funcStart === constraint.constraintSrcEB ? constraint.absoluteValue : null, current: i == (arr.length - 1) ? true : false }));
 		}
 	}
 	return res;

--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -47,7 +47,8 @@ function loadFromObject(obj) {
 			createBBLink(cell) //Create link
 		} else {
 			// Singled out functionSegList from obj as it doesn't show up in the graph after reading from JSON
-			var funcseg = obj.graph.cells[i].intention.attributes.evolvingFunction.attributes.functionSegList;
+			// var funcseg = obj.graph.cells[i].intention.attributes.evolvingFunction.attributes.functionSegList;
+			var funcseg = cell.attributes.intention.attributes.evolvingFunction.attributes.functionSegList;
 			createBBElement(cell, funcseg) //Create element
 		}
 	}

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -784,6 +784,7 @@ paper.on("link:options", function (cell) {
             // EVO.revertIntentionsText(graph.getElements(), paper);  
             var fileName = name + ".json";
             var obj = { graph: graph.toJSON() }; // Same structure as the other two save options
+            obj.version = "BloomingLeaf_2.0";
             download(fileName, stringifyCirc(obj));
             EVO.refresh(selectResult);
         }

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -730,7 +730,7 @@ paper.on("link:options", function (cell) {
             if (config.selected) { // If selected is true
                 selectedConfig = config.name; // Record the name of config
             }
-            var configBBM = new ConfigBBM({ name: config.name, action: config.action, conflictLevel: config.conflictLevel, numRelTime: config.numRelTime, currentState: config.currentState, userAssignmentsList: config.userAssignmentsList, previousAnalysis: config.previousAnalysis, selected: config.selected })
+            var configBBM = new ConfigBBM({ name: config.name, action: config.action, conflictLevel: config.conflictLevel, numRelTime: config.numRelTime, currentState: config.currentState, previousAnalysis: config.previousAnalysis, selected: config.selected })
             if (config.results.length !== 0) { // Creates results if there applicable
                 var results = configBBM.get('results'); // Grabs the coolection from the configBBM
                 // Individually creates each ResultBBM and add to collection
@@ -758,6 +758,11 @@ paper.on("link:options", function (cell) {
             currResult = configGroup[0].get('results').filter(selectedRes => selectedRes.get('name') == selectedResult)[0]
             currResult.set('selected', true);
         }
+    }
+
+    function loadOldConfig(oldAnalysisRequest) {
+        var configBBM = new ConfigBBM({conflictLevel: oldAnalysisRequest.conflictLevel, numRelTime: oldAnalysisRequest.numRelTime, currentState: oldAnalysisRequest.currentState})
+        configCollection.add(configBBM);
     }
 
     $(window).resize(function () {

--- a/leaf-ui/rappid-extensions/BackboneModelsIntention.js
+++ b/leaf-ui/rappid-extensions/BackboneModelsIntention.js
@@ -177,6 +177,7 @@ var IntentionBBM = Backbone.Model.extend({
 
     /**
      * Allows you to find the UserEvaluationBBM with the specified absTime
+     * If there is no absTime parameter passed into the function will return the first UserEvaluationBBM
      * If there is no UserEvaluationBBM with that absTime, return null
      * 
      * @param {Integer} absTime 
@@ -184,9 +185,20 @@ var IntentionBBM = Backbone.Model.extend({
      * @returns an UserEvaluationBBM or null
      */
     getUserEvaluationBBM: function (absTime) {
-        userEvals = this.get('userEvaluationList').filter(userEval => userEval.get('absTime') == absTime);
-        if (userEvals.length > 0) {
-            return userEvals[userEvals.length - 1]
+        // If absTime parameter is not passed in set it to null
+        absTime = absTime || null;
+
+        if (absTime != null) {
+            userEvals = this.get('userEvaluationList').filter(userEval => userEval.get('absTime') == absTime);
+            userEvals = this.get('userEvaluationList').at(0);
+            if (userEvals.length > 0) {
+                return userEvals[userEvals.length - 1]
+            }           
+        } 
+        // If there is no absTime passed in or there was no UserEvaluationBBM found for
+        // the absTime param, then return first UserEvaluationBBM added to the collection 
+        if (this.get('userEvaluationList')) {
+            return this.get('userEvaluationList').at(0);
         }
         return null;
     },


### PR DESCRIPTION
Previously, load-save only loaded models that had been saved on the newer version of BloomingLeaf, but now it can also load pre-backbone models. Addresses #638. 