### PR TITLE
actors now log merged intentions

### DIFF
--- a/leaf-analysis/src/merge/MMain.java
+++ b/leaf-analysis/src/merge/MMain.java
@@ -20,7 +20,7 @@ import simulation.BIModelSpecBuilder;
  *
  */
 public class MMain {
-	public final static boolean DEBUG = true;
+	public final static boolean DEBUG = false;
 
 	/**
 	 * This method is responsible to execute all steps to generate the merged model
@@ -32,18 +32,18 @@ public class MMain {
 		String tPath = "data/timing/";
 		String outPath = "data/mergedModels/";
 		String tracePath = "data/traceability/";
-		String inputFile1 = "S1-Part4.json";
-		String inputFile2 = "S1-Pre-Auto.json";
-		String timingFile = "S1-timing.json";
+		String inputFile1 = "";
+		String inputFile2 = "";
+		String timingFile = "";
 		String outputFile = "output.json";
 		
 		try {			
-//			if (args.length == 4) {
-//				inputFile1 = args[0];
-//				inputFile2 = args[1];
-//				timingFile = args[2];
-//				outputFile = args[3];
-//			} else throw new IOException("Tool: Command Line Inputs Incorrect.");
+			if (args.length == 4) {
+				inputFile1 = args[0];
+				inputFile2 = args[1];
+				timingFile = args[2];
+				outputFile = args[3];
+			} else throw new IOException("Tool: Command Line Inputs Incorrect.");
 			
 			if (DEBUG) System.out.println("Merging: \t" + inputFile1 + " and " + inputFile2);
 
@@ -80,7 +80,6 @@ public class MMain {
 
 			ModelSpec mergedModel = merge.getMergedModel();
 			if (DEBUG) System.out.println("Completed Merging.");
-			
 
 			// Create Output file that will be used by frontend
 			IMain mergedModelOut = IMainBuilder.buildIMain(mergedModel);

--- a/leaf-analysis/src/merge/MMain.java
+++ b/leaf-analysis/src/merge/MMain.java
@@ -20,7 +20,7 @@ import simulation.BIModelSpecBuilder;
  *
  */
 public class MMain {
-	public final static boolean DEBUG = false;
+	public final static boolean DEBUG = true;
 
 	/**
 	 * This method is responsible to execute all steps to generate the merged model
@@ -32,18 +32,18 @@ public class MMain {
 		String tPath = "data/timing/";
 		String outPath = "data/mergedModels/";
 		String tracePath = "data/traceability/";
-		String inputFile1 = "";
-		String inputFile2 = "";
-		String timingFile = "";
+		String inputFile1 = "S1-Part4.json";
+		String inputFile2 = "S1-Pre-Auto.json";
+		String timingFile = "S1-timing.json";
 		String outputFile = "output.json";
 		
 		try {			
-			if (args.length == 4) {
-				inputFile1 = args[0];
-				inputFile2 = args[1];
-				timingFile = args[2];
-				outputFile = args[3];
-			} else throw new IOException("Tool: Command Line Inputs Incorrect.");
+//			if (args.length == 4) {
+//				inputFile1 = args[0];
+//				inputFile2 = args[1];
+//				timingFile = args[2];
+//				outputFile = args[3];
+//			} else throw new IOException("Tool: Command Line Inputs Incorrect.");
 			
 			if (DEBUG) System.out.println("Merging: \t" + inputFile1 + " and " + inputFile2);
 
@@ -80,6 +80,7 @@ public class MMain {
 
 			ModelSpec mergedModel = merge.getMergedModel();
 			if (DEBUG) System.out.println("Completed Merging.");
+			
 
 			// Create Output file that will be used by frontend
 			IMain mergedModelOut = IMainBuilder.buildIMain(mergedModel);

--- a/leaf-analysis/src/merge/MergeAlgorithm.java
+++ b/leaf-analysis/src/merge/MergeAlgorithm.java
@@ -366,6 +366,11 @@ public class MergeAlgorithm {
 		for(Intention intention: otherModel.getIntentions()) {
 			if(intention.getActor() == oldActor){
 				intention.setActor(newActor);
+				//add intention to new actor
+				boolean added = newActor.addEmbed((AbstractElement)intention);
+
+				if(MMain.DEBUG && added) System.out.println("intention " + intention.getName() + " added to newActor " + newActor.getName());
+				
 			}
 		}
 

--- a/leaf-analysis/src/simulation/Actor.java
+++ b/leaf-analysis/src/simulation/Actor.java
@@ -3,6 +3,11 @@
  */
 package simulation;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import merge.MMain;
+
 /**
  * @author A.M.Grubb
  *
@@ -31,9 +36,23 @@ public class Actor extends AbstractLinkableElement {
 	}
 	
 	/*
-	 * Return ids of intentions embedded in the actor
+	 * Return ids of intentions (and links, for some reason) embedded in the actor
 	 */
 	public String[] getEmbeds() {
 		return embeds;
+	} 
+	
+	public boolean addEmbed(AbstractElement newEmbed) {
+		
+		for(String id: embeds) {
+			if(id.equals(newEmbed.getUniqueID())) return false;
+		}
+		ArrayList<String> temp_embeds = new ArrayList<String>(Arrays.asList(embeds));
+		temp_embeds.add(newEmbed.getUniqueID());
+		embeds = new String[temp_embeds.size()];
+		for(int i = 0; i < embeds.length; i ++) {
+			embeds[i] = temp_embeds.get(i);
+		}
+		return true;
 	}
 }

--- a/leaf-analysis/src/simulation/Actor.java
+++ b/leaf-analysis/src/simulation/Actor.java
@@ -42,6 +42,11 @@ public class Actor extends AbstractLinkableElement {
 		return embeds;
 	} 
 	
+	/**
+	 * Add a new element to be embedded in this Actor
+	 * @param newEmbed
+	 * @return if it has been added
+	 */
 	public boolean addEmbed(AbstractElement newEmbed) {
 		
 		for(String id: embeds) {


### PR DESCRIPTION
Originally, intentions will log their new actor objects, but actors would not keep track of new intentions. I added a method to update the elements embedded in an actor and added a line in the merge algorithm so that a new actor object will collect the unique IDs of any intentions that the actor version in the other model has but the new one doesn't. (When MMain.DEBUG = true console outputs will show when an intention has been added to a new actor) (Changes in MMain are not important, just for running stuff)