### PR TITLE
Font size bugs

### DIFF
--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -1069,7 +1069,7 @@ function revertNodeValuesToInitial(analysisResult) {
         } else {
             curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
         }
-        curr.attr({ text: { fill: 'black', stroke: 'none', 'font-weight': 'normal', 'font-size': 10 } });
+        // curr.attr({ text: { fill: 'black', stroke: 'none', 'font-weight': 'normal', 'font-size': current_font } });
     }
     // Remove slider
     if (analysisResult !== undefined) {

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -1069,7 +1069,7 @@ function revertNodeValuesToInitial(analysisResult) {
         } else {
             curr.attr('.satvalue/text', satisfactionValuesDict[initSatVal].satValue);
         }
-        // curr.attr({ text: { fill: 'black', stroke: 'none', 'font-weight': 'normal', 'font-size': current_font } });
+        
     }
     // Remove slider
     if (analysisResult !== undefined) {


### PR DESCRIPTION
Switching from Analysis/Modeling and vice versa will now keep the font size. You can still increase/decrease the font again.
I narrowed down the bug to one code in CSS that was fixing the bug. I think we can just get rid of that line because it doesn't seem to do much either way.