### PR TITLE
Renamed 'undo' to 'undo move' and 'redo' to 'redo move'

### DIFF
--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -42,8 +42,8 @@
         <div class="dropdown">
             <button id="btn-edit" class="btn">Edit</button>
             <div class="dropdown-toolbar">
-                <a id="btn-undo" class='model-only'>Undo</a>
-                <a id="btn-redo" class='model-only'>Redo</a>
+                <a id="btn-undo" class='model-only'>Undo Move</a>
+                <a id="btn-redo" class='model-only'>Redo Move</a>
                 <a id="btn-clear-all" class='model-only'>Clear Full Model and Analysis</a>
                 <a id="btn-clear-elabel" class='model-only'>Clear Evaluation Labels</a>
                 <a id="btn-clear-flabel" class='model-only'>Clear Dynamic Function Labels</a>


### PR DESCRIPTION
This PR updates the name of the undo and redo buttons, so that users won't assume it does more than just undo moves.