### PR TITLE
Ev0 deleted changes

### DIFF
--- a/leaf-ui/css/style.css
+++ b/leaf-ui/css/style.css
@@ -688,3 +688,17 @@ padding: 0px 20px 0px 0px;
   padding: 5px;
   text-align: center;
 }
+
+/** buttons for the palette customization */
+.button-container {
+  display: flex;
+  justify-content: space-between;
+}
+
+.top-left-button {
+  align-self: flex-start;
+}
+
+.top-right-button {
+  align-self: flex-start;
+}

--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -134,12 +134,9 @@
             <div id="page-mask"></div>
                     <div class="popup_content">
                     
-                        <div class="popup_header">
-
-                            <span id="submit-color" class="close" onclick=" $('#color-input').css('display', 'none');">&times;</span>
-
+                        <div class="popup_header"> 
                             <h2>Create My Palette</h2>
-                        </div>
+                        </div>                            
                         <div class="popup_body">
                             <h3 style="text-align:left; color:#1E85F7; margin-bottom:5px;">Initial Satisfied Value</h3>
                             <table id="initial-satisfied-list" class="abs-table">
@@ -153,11 +150,11 @@
                             
                                     </tr>
                                     <tr>
-                                        <td><input type="color" value="#D3D3D3" id="my-None" class="analysis-input" /></td>
+                                        <td><input type="color" value= "#D3D3D3" id="my-None" class="analysis-input" /></td>
                                         <td><input type="color" value="#003fff" id="my-Satisfied" class="analysis-input" /></td>
                                         <td><input type="color" value="#8FB8DE" id="my-PS" class="analysis-input" /></td>
                                         <td><input type="color" value="#fbaca8" id="my-PD" class="analysis-input" /></td>
-                                        <td><input type="color" value="#9400D3" id="my-Denied" class="analysis-input" /></td>
+                                        <td><input type="color" value="#FF2600" id="my-Denied" class="analysis-input" /></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -171,16 +168,17 @@
                                         <th>(F, F)</th>
                                     </tr>
                                     <tr>
-                                        <td><input type="color" value="#5946b2" id="my-PP" class="analysis-input" type="number" /></td>
-                                        <td><input type="color" value="#FF2600" id="my-FP" class="analysis-input" type="number" /></td>
+                                        <td><input type="color" value="#9400D3" id="my-PP" class="analysis-input" type="number" /></td>
+                                        <td><input type="color" value="#5946b2" id="my-FP" class="analysis-input" type="number" /></td>
                                         <td><input type="color" value="#ca2c92" id="my-PF" class="analysis-input" type="number" /></td>
                                         <td><input type="color" value="#0D0221" id="my-FF" class="analysis-input" type="number" /></td>
                                     </tr>
                                 </tbody>
                             </table>
-                            <div class="button" style="text-align: right;  padding: 10px">
+                            <div class="button-container" style="padding: 10px">
+                               <span>  <button class="top-left-button" id="cancel-customization" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px; align-self;" onclick=" $('#color-input').css('display', 'none');"> Cancel </button> </span>
                                <span id="saved-options-message" style = "display: none;">   Your options are now saved! </span>
-                               <span>  <button id="submit-color" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px"> Save my palette </button> </span>
+                               <span>  <button id="submit-color" class="top-right-button" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px"> Save my palette </button> </span>
                             </div>
                         </div>
                     </div>

--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -176,7 +176,7 @@
                                 </tbody>
                             </table>
                             <div class="button-container" style="padding: 10px">
-                               <span>  <button class="top-left-button" id="cancel-customization" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px; align-self;" onclick=" $('#color-input').css('display', 'none');"> Cancel </button> </span>
+                               <span>  <button class="top-left-button" id="cancel-customization" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px; align-self;" > Cancel </button> </span>
                                <span id="saved-options-message" style = "display: none;">   Your options are now saved! </span>
                                <span>  <button id="submit-color" class="top-right-button" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px"> Save my palette </button> </span>
                             </div>

--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -89,7 +89,7 @@
                 <a id="color-palette-2"> Red-Green Palette</a>
                 <a id="color-palette-3"> Green-Black Palette</a>
                 <a id="color-palette-4"> Yellow-Purple Palette</a>
-                <a id="color-palette-5"> EVO Colorblind Mode</a>
+                <a id="color-palette-5"> Color-Blind Palette</a>
                 <a id="color-palette-6"> My Palette</a> 
                 <a id="color-palette-7">  Edit My Palette</a> 
                 </div>

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -56,19 +56,6 @@ class EVO {
         "1111": "#0D0221"  // Conflict (F, F)
     };
 
-    // Replaces all conflicting evals with dark grey
-    static colorVisDictColorBlind = {
-        "0000": "#D3D3D3",
-        "0011": "#003fff",
-        "0010": "#8FB8DE",
-        "0100": "#fbaca8",
-        "0110": "#333333",
-        "0111": "#333333",
-        "1100": "#FF2600",
-        "1110": "#333333",
-        "1111": "#333333"
-    };
-
     // The Red-Green Palette
     static colorVisDict2 = {
         "0000": "#bdaead",
@@ -105,6 +92,19 @@ class EVO {
         "0111": "#d69d00",
         "1100": "#A020F0",
         "1110": "#5946b2",
+        "1111": "#0D0221"
+    };
+
+    // Color Blind palette
+    static colorVisDictColorBlind = {
+        "0000": "#FFFF00",
+        "0011": "#FF0000",
+        "0010": "#CCCCCC",
+        "0100": "#CCCCCC",
+        "0110": "#CCCCCC",
+        "0111": "#CCCCCC",
+        "1100": "#0000FF",
+        "1110": "#CCCCCC",
         "1111": "#0D0221"
     };
 
@@ -640,7 +640,7 @@ class EVO {
      * Fill in self-dictionary
      */
     static fillInDictionary() {
-        if (EVO.paletteOption == 7 & document.getElementById("my-Satisfied").value!= document.getElementById("my-Denied").value) {
+        if (EVO.paletteOption == 7 & document.getElementById("my-Satisfied").value!= document.getElementById("my-Denied").value & document.getElementById("my-Satisfied").value!= document.getElementById("my-None").value & document.getElementById("my-Satisfied").value!= document.getElementById("my-FF").value & document.getElementById("my-Denied").value!= document.getElementById("my-None").value & document.getElementById("my-FF").value!= document.getElementById("my-Denied").value & document.getElementById("my-None").value!= document.getElementById("my-FF").value ){
             EVO.selfColorVisDict = {
                 "0000": document.getElementById("my-None").value,
                 "0011": document.getElementById("my-Satisfied").value,

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -640,7 +640,7 @@ class EVO {
      * Fill in self-dictionary
      */
     static fillInDictionary() {
-        if (EVO.paletteOption == 7) {
+        if (EVO.paletteOption == 7 & document.getElementById("my-Satisfied").value!= document.getElementById("my-Denied").value) {
             EVO.selfColorVisDict = {
                 "0000": document.getElementById("my-None").value,
                 "0011": document.getElementById("my-Satisfied").value,
@@ -651,8 +651,12 @@ class EVO {
                 "1100": document.getElementById("my-Denied").value,
                 "1110": document.getElementById("my-PF").value,
                 "1111": document.getElementById("my-FF").value
-            }
-        }    
+            };
+            return true
+        } else{
+            return false  
+        }
+        
     }
 }
 
@@ -778,15 +782,6 @@ class EVONextState {
             return selfVis[intentionEval];
         }
 
-    }
-
-
-    /**
-     * Validates if the input colors are hexcolor
-     */
-    static validateColor(color) {
-        const COLOR_PATTERN = new RegExp("^(#[a-fA-F0-9]{6})$");
-        return COLOR_PATTERN.test(color);
     }
 
 

--- a/leaf-ui/js/object/evoObjects.js
+++ b/leaf-ui/js/object/evoObjects.js
@@ -97,15 +97,18 @@ class EVO {
 
     // Color Blind palette
     static colorVisDictColorBlind = {
-        "0000": "#FFFF00",
-        "0011": "#FF0000",
-        "0010": "#CCCCCC",
-        "0100": "#CCCCCC",
-        "0110": "#CCCCCC",
-        "0111": "#CCCCCC",
-        "1100": "#0000FF",
-        "1110": "#CCCCCC",
-        "1111": "#0D0221"
+     
+        "0000": "#CCCCCC", // None (⊥, ⊥)
+        "0011": "#0000FF", // Satisfied (F, ⊥)
+        "0010": "#0000FF", // Partially satisfied (P, ⊥)
+        "0100": "#FF0000", // Partially denied (⊥, P)
+        "0110": "#FFFF00", // Conflict (P, P)
+        "0111": "#FFFF00", // Conflict (F, P)
+        "1100": "#FF0000", // Fully denied (⊥, F)
+        "1110": "#FFFF00", // Conflict (P, F)
+        "1111": "#FFFF00"  // Conflict (F, F)
+
+        
     };
 
     //Initialize user-created-palette as Red-Blue

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -3,6 +3,7 @@ This file contains all the jQuery functions that are associated with buttons and
 It also contains the setup for Rappid elements.
 */
 
+
 // Used to be onFunctionsBothWindows.js
 // Navigation bar functions:
 var max_font = 20;
@@ -1008,30 +1009,38 @@ paper.on("link:options", function (cell) {
 
     //Show warning messages if use input invalid color
     $('#submit-color').on('click', function () {
-        //fill in the dictionary
-        EVO.fillInDictionary();
-
-        //check that the entered colors are different
-        if (validateColor(EVO.selfColorVisDict) == false) { swal("Please make sure your satisfied and denied values are different", "", "error"); }
-
-        // Display a message to tell the user their selection is saved
-        $("#saved-options-message").css("display", "");
-        setTimeout(function(){
-            $("#saved-options-message").css("display", "none");
-            //close the color input
-            $('#color-input').css("display", "none");
-        }, 500);
-    
-        // refresh the visual overlay on the model and the palette dropdown
-        EVO.paletteOption =6;
-        highlightPalette(EVO.paletteOption);
-        if ($('#analysisSlider').css("display") == "none") {
-            EVO.refresh(undefined);
-        } else {
-            EVO.refresh(selectResult);
+       
+        //check that the entered colors for the satisfied and  denied values are different
+        if (!EVO.fillInDictionary()) 
+        {
+            //changes the color for fully satisfied and fully denied to what they were 
+            document.getElementById('my-Satisfied').value=EVO.selfColorVisDict["0011"];
+            document.getElementById('my-Denied').value=  EVO.selfColorVisDict["1100"];
+            //error messsage 
+            swal("Please make sure your satisfied and denied values are different",   "", "error")
+            
         }
+        else{
+            // Display a message to tell the user their selection is saved
+            $("#saved-options-message").css("display", "");
+            setTimeout(function(){
+                $("#saved-options-message").css("display", "none");
+                //close the color input
+                $('#color-input').css("display", "none");
+            }, 500);
+        
+            // refresh the visual overlay on the model and the palette dropdown
+            EVO.paletteOption =6;
+            highlightPalette(EVO.paletteOption);
+            if ($('#analysisSlider').css("display") == "none") {
+                EVO.refresh(undefined);
+            } else {
+                EVO.refresh(selectResult);
+            }
+        };
         
     });
+   
 
     /**
      * Source:https://www.w3schools.com/howto/howto_js_rangeslider.asp 
@@ -1267,12 +1276,5 @@ function unhighlightPalettes() {
     }
 }
 
-/**
- * Checks if the color selections for satisfied and denied are different
- * @param {*} colorDict 
- * @returns {boolean}
- */
-function validateColor(colorDict) {
-    return colorDict[ "0011"] != colorDict["1100"];
-}
+
     

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -257,7 +257,7 @@ function displayPalette(palette_number ) {
         '</tbody>'+
         '</table>',
     550, 'alert', 'warning');
-   
+
     //updates the color key based on the chosen palette 
     if(palette_number<6){
         //pre-made palettes
@@ -298,6 +298,8 @@ $('#evo-color-key').on('click', function () {
         'onclick="displayPalette(3)" style="width:100%"> Green-Black Palette' +
         '</button><button type="button" class="model-editing" ' +
         'onclick="displayPalette(4)" style="width:100%"> Yellow-Purple Palette' +
+        '</button><button type="button" class="model-editing" ' +
+        'onclick="displayPalette(5)" style="width:100%">Color-Blind Palette' +
         '</button><button type="button" class="model-editing" ' +
         'onclick="displayPalette(6)" style="width:100%"> My Palette' +
         '</button></p>',
@@ -1016,8 +1018,10 @@ paper.on("link:options", function (cell) {
             //changes the color for fully satisfied and fully denied to what they were 
             document.getElementById('my-Satisfied').value=EVO.selfColorVisDict["0011"];
             document.getElementById('my-Denied').value=  EVO.selfColorVisDict["1100"];
+            document.getElementById('my-None').value=  EVO.selfColorVisDict["0000"];
+            document.getElementById('my-FF').value=  EVO.selfColorVisDict["1111"];
             //error messsage 
-            swal("Please make sure your satisfied and denied values are different",   "", "error")
+            swal("Please make sure your satisfied, denied, none, and FF values are different from one another",   "", "error")
             
         }
         else{

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -1040,6 +1040,21 @@ paper.on("link:options", function (cell) {
         };
         
     });
+
+    //cancel edits to palette customization
+    $('#cancel-customization').on('click', function () { 
+        document.getElementById('my-Satisfied').value=EVO.selfColorVisDict["0011"];
+        document.getElementById('my-Denied').value=  EVO.selfColorVisDict["1100"];
+        document.getElementById('my-None').value=  EVO.selfColorVisDict["0000"];
+        document.getElementById('my-PS').value=  EVO.selfColorVisDict["0010"];
+        document.getElementById('my-PD').value=  EVO.selfColorVisDict["0100"];
+        document.getElementById('my-PP').value=  EVO.selfColorVisDict["0110"];
+        document.getElementById('my-FP').value=  EVO.selfColorVisDict["0111"];
+        document.getElementById('my-PF').value=  EVO.selfColorVisDict["1110"];
+        document.getElementById('my-FF').value=  EVO.selfColorVisDict["1111"];
+        $('#color-input').css("display", "none");
+
+    });
    
 
     /**


### PR DESCRIPTION
This branch builds on the last PR for EVO, but some last changes were lost and/or not fully functional
- a confirmation message to tell the user their palette options have been saved
- show an error message when the chosen satisfied and denied values are the same 
Additional features now include:
- a cancel button to cancel all new changes to my palette => it restores it to what it was when "save changes" was last clicked on

- when the user picks the same color (same hex code) for satisfied and denied they not only get the error message but the "create my palette tab" remains open and the values for satisfied and denied don't change until they pick different ones as shown in these three pictures

1- Make changes (picked the same color for satisfied and denied on purpose)
<img width="676" alt="Screenshot 2023-05-17 at 3 59 14 PM" src="https://github.com/amgrubb/BloomingLeaf/assets/133876033/8b7e45d2-421b-4ac2-a78b-29bd003071ad">

2-save
<img width="676" alt="Screenshot 2023-05-17 at 3 59 26 PM" src="https://github.com/amgrubb/BloomingLeaf/assets/133876033/695a06ae-befd-4634-8416-07a4b852f4f2">

3-click on ok ( satisfied and denied go back to what they were before automatically and the color key remains untouched)
<img width="676" alt="Screenshot 2023-05-17 at 3 59 34 PM" src="https://github.com/amgrubb/BloomingLeaf/assets/133876033/1630e36f-78a4-4f99-8b51-c78b272745eb">
