### PR TITLE
Fix clear of evaluation evaluation and evidence pairs

### DIFF
--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -46,7 +46,7 @@
                 <a id="btn-redo" class='model-only'>Redo Move</a>
                 <a id="btn-clear-all" class='model-only'>Clear Full Model and Analysis</a>
                 <a id="btn-clear-elabel" class='model-only'>Clear Evaluation Labels</a>
-                <a id="btn-clear-flabel" class='model-only'>Clear Dynamic Function Labels</a>
+                <a id="btn-clear-flabel" class='model-only'>Clear Evolving Function Labels</a>
                 <a id="btn-clear-cycle" class='model-only'>Clear Cycle Highlighting</a>
                 <a id="btn-clear-results" class='analysis-only' style="display: none;">Clear Results Only</a>
                 <a id="btn-clear-analysis" class='analysis-only' style="display: none;">Clear Requests and

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -170,6 +170,12 @@ $('#btn-undo').on('click', _.bind(commandManager.undo, commandManager));
 $('#btn-redo').on('click', _.bind(commandManager.redo, commandManager));
 $('#btn-clear-all').on('click', function () { clearAll() });
 $('#btn-clear-flabel').on('click', function () {
+    removeHighlight();
+    if ($('.analysis-only').css("display") == "none") {
+        clearInspector();
+    } else {
+        setName();
+    }
     for (let element of graph.getElements()) {
         var cellView = element.findView(paper);
         var cell = cellView.model;
@@ -920,6 +926,12 @@ paper.on("link:options", function (cell) {
 
 
     $('#btn-clear-elabel').on('click', function () {
+        removeHighlight();
+        if ($('.analysis-only').css("display") == "none") {
+            clearInspector();
+        } else {
+            setName();
+        }
         for (let element of graph.getElements()) {
             var cell = element.findView(paper).model;
             var intention = cell.get('intention');

--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -170,7 +170,7 @@ $('#btn-undo').on('click', _.bind(commandManager.undo, commandManager));
 $('#btn-redo').on('click', _.bind(commandManager.redo, commandManager));
 $('#btn-clear-all').on('click', function () { clearAll() });
 $('#btn-clear-flabel').on('click', function () {
-    removeHighlight();
+    removeHighlight(); // deselects intention
     if ($('.analysis-only').css("display") == "none") {
         clearInspector();
     } else {
@@ -926,7 +926,7 @@ paper.on("link:options", function (cell) {
 
 
     $('#btn-clear-elabel').on('click', function () {
-        removeHighlight();
+        removeHighlight(); // deselects intention
         if ($('.analysis-only').css("display") == "none") {
             clearInspector();
         } else {

--- a/leaf-ui/rappid-extensions/ElementInspector.js
+++ b/leaf-ui/rappid-extensions/ElementInspector.js
@@ -1134,8 +1134,6 @@ var FuncSegView = Backbone.View.extend({
             var funcType = this.intention.get('evolvingFunction').get('type');
             var initVal = satisfactionValuesDict[this.intention.getUserEvaluationBBM(0).get('assignedEvidencePair')].chartVal;
             this.chart.reset();
-            // Get the chart canvas
-            var context = $("#chart").get(0).getContext("2d");
 
             // Render preview for user defined function types
             if (funcType == "UD") {
@@ -1179,7 +1177,11 @@ var FuncSegView = Backbone.View.extend({
                     this.chart.addDataSet(0, [initVal], false);
                 }
             }
-            this.chart.display(context);
+            if ($("#chart").get(0)) { // if the chart is displayed on the page
+                // Get the chart canvas
+                var context = $("#chart").get(0).getContext("2d");
+                this.chart.display(context);
+            }
         }
     },
 

--- a/leaf-ui/rappid-extensions/ElementInspector.js
+++ b/leaf-ui/rappid-extensions/ElementInspector.js
@@ -730,14 +730,16 @@ var ElementInspector = Backbone.View.extend({
     } else if (this.intention.get('evolvingFunction') != null && this.intention.getUserEvaluationBBM(0).get('assignedEvidencePair') !== null && this.intention.get('evolvingFunction').get('type') === 'NT') {
         // Clear previous chart values
         this.chart.reset();
-        // Gets the chart canvas
-        var context = $("#chart").get(0).getContext("2d");
         // Adds the initial satisfaction as a single point to the chart
         this.chart.addDataSet(0, [satisfactionValuesDict[this.intention.getUserEvaluationBBM(0).get('assignedEvidencePair')].chartVal], false);
         // Renders the chart
-        this.chart.display(context);
+        if ($("#chart").get(0)) { // if the chart is displayed on the page
+            // Gets the chart canvas
+            var context = $("#chart").get(0).getContext("2d");
+            this.chart.display(context);
         }
-    },
+    }
+},
 
     /**
      * Called whenever the html is updated. Renders the views for the FunctionSegmentBBMs and adds an absTime label


### PR DESCRIPTION
fixed the issue in which an error pops up when an intention was set with a sat value and a function type and the user clears the evolving function labels and evaluation labels. 

We fixed it by not displaying the chart after clearing.

Fixed #708 