### PR TITLE
Fix disappearing slider when switching color palettes

### DIFF
--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -1080,7 +1080,6 @@ paper.on("link:options", function (cell) {
      */
     document.getElementById("colorResetAnalysis").oninput = function () { // Changes slider mode and refreshes
         var selectConfig;
-        //TODO: Find out why the selectResult is empty before we reassign it
         if (configCollection.length !== 0) {
             selectConfig = configCollection.filter(Config => Config.get('selected') == true)[0];
             if (selectConfig.get('results') !== undefined) {

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -15,6 +15,7 @@ var ResultView = Backbone.View.extend({
     initialize: function (options) {
         this.config = options.config;
         this.model.on('change:selected', this.updateHighlight, this);
+        setSelectResult(this.model);
     },
 
     template: ['<script type="text/template" id="result-template">',


### PR DESCRIPTION
fixed the issue in which the slider disappears when switching color palettes by updating the variable select results when simulate path is clicked

Fixed #663 