### PR TITLE
Fix analysis results showing up from an old model after loading in a different model

### DIFF
--- a/leaf-ui/js/loadSaveFunctions.js
+++ b/leaf-ui/js/loadSaveFunctions.js
@@ -64,6 +64,8 @@ function loadFromObject(obj) {
 	// If the object contains configCollection, create configCollection fields from JSON
 	if (obj.configCollection != undefined) {
 		loadConfig(obj.configCollection)
+	} else {
+		resetConfig();
 	}
 }
 

--- a/leaf-ui/js/sliderObjects.js
+++ b/leaf-ui/js/sliderObjects.js
@@ -37,6 +37,9 @@ class SliderObj {
      */
     static displayAnalysis(analysisResult, isSwitch) {
         // Check if slider has already been initialized
+        if (analysisResult.get('slider') == null) {
+            analysisResult.set('slider', new SliderObj());
+        }
         if (analysisResult.get('slider').sliderElement.hasOwnProperty('noUiSlider')) {
             analysisResult.get('slider').sliderElement.noUiSlider.destroy();
         }


### PR DESCRIPTION
Fixes Issue 669, in which Results from an old model would show up in Analysis after loading in a new model.
This issue was fixed by resetting configCollection when loading a new model.
The solution was tested by creating a model and simulating paths, then loading saved models both with and without saved results. 

Also found and fixed a bug in which loaded models do not have a slider element during simulation.

Fixed #669