### PR TITLE
Fix pagination in next state window for 4+ digit numbers

### DIFF
--- a/leaf-ui/index.html
+++ b/leaf-ui/index.html
@@ -176,7 +176,7 @@
                                 </tbody>
                             </table>
                             <div class="button-container" style="padding: 10px">
-                               <span>  <button class="top-left-button" id="cancel-customization" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px; align-self;" > Cancel </button> </span>
+                               <span>  <button class="top-left-button" id="cancel-customization" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px;" > Cancel </button> </span>
                                <span id="saved-options-message" style = "display: none;">   Your options are now saved! </span>
                                <span>  <button id="submit-color" class="top-right-button" style="background-color: #1E85F7; color: white; padding: 8px 20px; font-size:15px"> Save my palette </button> </span>
                             </div>

--- a/leaf-ui/js/next-state.js
+++ b/leaf-ui/js/next-state.js
@@ -240,34 +240,29 @@
      * The number of the page that is selected in the next State window 
      */
     function updatePagination(currentPage) {
+        var currentDigits = currentPage.toString().length;
         var pagination = document.getElementById("pagination");
         var nextSteps_array_size = allSolutionArray.length;
         if (nextSteps_array_size > 6) {
             renderPreviousBtn(pagination, currentPage);
             if (currentPage - 3 < 0) {
-                for (var i = 0; i < 6; i++) {
+                for (var i = 0; i < 7; i++) {
                     render_pagination_values(currentPage, i);
                 }
             } else {
-                if (currentPage < 100) {
-                    if (currentPage + 3 < nextSteps_array_size) {
-                        for (i = currentPage - 3; i < currentPage + 3; i++) {
-                            render_pagination_values(currentPage, i);
-                        }
-                    } else {
-                        for (i = currentPage - 3; i < nextSteps_array_size; i++) {
-                            render_pagination_values(currentPage, i);
-                        }
+                var numBefore = Math.ceil((7 - currentDigits)/2);
+                var numAfter = Math.ceil((8 - currentDigits)/2);
+                if (numAfter < 1) {
+                    numAfter = 1;
+                }
+                console.log(numBefore, numAfter);
+                if (currentPage + numBefore < nextSteps_array_size) {
+                    for (i = currentPage - numBefore; i < currentPage + numAfter; i++) {
+                        render_pagination_values(currentPage, i);
                     }
                 } else {
-                    if (currentPage + 2 < nextSteps_array_size) {
-                        for (i = currentPage - 2; i < currentPage + 3; i++) {
-                            render_pagination_values(currentPage, i);
-                        }
-                    } else {
-                        for (i = currentPage - 3; i < nextSteps_array_size; i++) {
-                            render_pagination_values(currentPage, i);
-                        }
+                    for (i = currentPage - numAfter; i < nextSteps_array_size; i++) {
+                        render_pagination_values(currentPage, i);
                     }
                 }
             }

--- a/leaf-ui/js/next-state.js
+++ b/leaf-ui/js/next-state.js
@@ -240,7 +240,7 @@
      * The number of the page that is selected in the next State window 
      */
     function updatePagination(currentPage) {
-        var currentDigits = currentPage.toString().length;
+        var currentDigits = currentPage.toString().length; // number of digits in the selected page number
         var pagination = document.getElementById("pagination");
         var nextSteps_array_size = allSolutionArray.length;
         if (nextSteps_array_size > 6) {
@@ -250,12 +250,11 @@
                     render_pagination_values(currentPage, i);
                 }
             } else {
-                var numBefore = Math.ceil((7 - currentDigits)/2);
-                var numAfter = Math.ceil((8 - currentDigits)/2);
-                if (numAfter < 1) {
+                var numBefore = Math.ceil((7 - currentDigits)/2); // number of digits displayed to the left of the selected page number
+                var numAfter = Math.ceil((8 - currentDigits)/2); // number of digits displayed to the right of and including the selected page number
+                if (numAfter < 1) { // must show at least one digit
                     numAfter = 1;
                 }
-                console.log(numBefore, numAfter);
                 if (currentPage + numBefore < nextSteps_array_size) {
                     for (i = currentPage - numBefore; i < currentPage + numAfter; i++) {
                         render_pagination_values(currentPage, i);

--- a/leaf-ui/js/next-state.js
+++ b/leaf-ui/js/next-state.js
@@ -239,20 +239,23 @@
      * @param {Integer} currentPage
      * The number of the page that is selected in the next State window 
      */
-    function updatePagination(currentPage) {
+    function updatePagination(currentPage) { 
         var currentDigits = currentPage.toString().length; // number of digits in the selected page number
         var pagination = document.getElementById("pagination");
         var nextSteps_array_size = allSolutionArray.length;
+        var numBefore = Math.ceil((7 - currentDigits)/2); // number of digits displayed to the left of the selected page number
+        var numAfter = Math.ceil((8 - currentDigits)/2); // number of digits displayed to the right of and including the selected page number
         if (nextSteps_array_size > 7) {
             renderPreviousBtn(pagination, currentPage);
             if (currentPage - 3 < 0) { // if current page number is low cannot be the middle number
                 for (var i = 0; i < 7; i++) {
                     render_pagination_values(currentPage, i);
                 }
-            // } else if () { // if current page number is high cannot be the middle number
+            } else if (currentPage > nextSteps_array_size - numBefore) { // if current page number is high cannot be the middle number
+                for (i = (nextSteps_array_size) - (numBefore + numAfter); i < nextSteps_array_size; i++){
+                    render_pagination_values(currentPage, i); //if current page is beyond the possible amount of page it would set the page the user is on as the last possible page
+                }
             } else {
-                var numBefore = Math.ceil((7 - currentDigits)/2); // number of digits displayed to the left of the selected page number
-                var numAfter = Math.ceil((8 - currentDigits)/2); // number of digits displayed to the right of and including the selected page number
                 if (numAfter < 1) { // must show at least one digit
                     numAfter = 1;
                 }
@@ -324,8 +327,8 @@
         var nextSteps_array_size = allSolutionArray.length;
 
         if ((requiredState != "NaN") && (requiredState > 0)) {
-            if (requiredState > nextSteps_array_size) {
-                renderNavigationSidebar(nextSteps_array_size);
+            if (requiredState > nextSteps_array_size - 1) {
+                renderNavigationSidebar(nextSteps_array_size - 1); //makes sure required states is always within the possible maximum value of pages
             } else {
                 renderNavigationSidebar(requiredState);
             }

--- a/leaf-ui/js/next-state.js
+++ b/leaf-ui/js/next-state.js
@@ -243,24 +243,25 @@
         var currentDigits = currentPage.toString().length; // number of digits in the selected page number
         var pagination = document.getElementById("pagination");
         var nextSteps_array_size = allSolutionArray.length;
-        if (nextSteps_array_size > 6) {
+        if (nextSteps_array_size > 7) {
             renderPreviousBtn(pagination, currentPage);
-            if (currentPage - 3 < 0) {
+            if (currentPage - 3 < 0) { // if current page number is low cannot be the middle number
                 for (var i = 0; i < 7; i++) {
                     render_pagination_values(currentPage, i);
                 }
+            // } else if () { // if current page number is high cannot be the middle number
             } else {
                 var numBefore = Math.ceil((7 - currentDigits)/2); // number of digits displayed to the left of the selected page number
                 var numAfter = Math.ceil((8 - currentDigits)/2); // number of digits displayed to the right of and including the selected page number
                 if (numAfter < 1) { // must show at least one digit
                     numAfter = 1;
                 }
-                if (currentPage + numBefore < nextSteps_array_size) {
+                if (currentPage + numBefore < nextSteps_array_size) { // show the numbers less than the current page number
                     for (i = currentPage - numBefore; i < currentPage + numAfter; i++) {
                         render_pagination_values(currentPage, i);
                     }
                 } else {
-                    for (i = currentPage - numAfter; i < nextSteps_array_size; i++) {
+                    for (i = currentPage - numAfter; i < nextSteps_array_size; i++) { // show the numbers equal to and greater than the current page number
                         render_pagination_values(currentPage, i);
                     }
                 }


### PR DESCRIPTION
fixed the issue where in the next state window when the number of states the user selects exceeds over 1000 the user has to scroll to the side to find the arrow to go next 

Fixed #667 