### PR TITLE
Disable Explore Next States button on last state

### DIFF
--- a/leaf-ui/css/analysis_html.css
+++ b/leaf-ui/css/analysis_html.css
@@ -248,6 +248,12 @@ body {
   transform: translateY(2px);
 }
 
+.inspector-btn.disabled {
+  opacity: .75;
+  box-shadow: none;
+  pointer-events: none;
+}
+
 /* Add color overlay over the go buttons and click effect */
 .inspector-btn-small:active {
   background-color: #fffefe;

--- a/leaf-ui/js/next-state.js
+++ b/leaf-ui/js/next-state.js
@@ -197,6 +197,14 @@
         var pagination = document.getElementById("pagination");
         var num_states_lbl = document.getElementById("num_states_lbl");
         var currentPageIn = document.getElementById("currentPage");
+
+        // disable Explore Next States button if last time point
+        var exploreNextStatesBtn = document.getElementById("exploreNextStates");
+        if (myInputJSObject.results.get('timePointPath').length == myInputJSObject.results.totalNumTimePoints.length - 1) {
+            exploreNextStatesBtn.disabled = true;
+            exploreNextStatesBtn.classList.add('disabled');
+        }
+
         // Clear any previous pages by reseting page values
         pagination.innerHTML = "";
         num_states_lbl.innerHTML = "";


### PR DESCRIPTION
Fixes Issue #687 by disabling the "Explore Next States" button when viewing the last state. The button is no longer clickable and is visually greyed out. 

This can be tested by increasing the number of relative time points in the simulation, then using the Explore States button and clicking through to the last state.

Fixed #687