### PR TITLE
Fix slider disappearing in EVO off mode

### DIFF
--- a/leaf-ui/js/onFunctions.js
+++ b/leaf-ui/js/onFunctions.js
@@ -1080,7 +1080,6 @@ paper.on("link:options", function (cell) {
      */
     document.getElementById("colorResetAnalysis").oninput = function () { // Changes slider mode and refreshes
         var selectConfig;
-        //TODO: Find out why the selectResult is empty before we reassign it
         if (configCollection.length !== 0) {
             selectConfig = configCollection.filter(Config => Config.get('selected') == true)[0];
             if (selectConfig.get('results') !== undefined) {

--- a/leaf-ui/rappid-extensions/BackboneModelsAnalysis.js
+++ b/leaf-ui/rappid-extensions/BackboneModelsAnalysis.js
@@ -117,6 +117,7 @@ var ConfigBBM = Backbone.Model.extend({
         this.get("results").add(result);
         $('#conflict-level').prop('disabled', true);
         $('#num-rel-time').prop('disabled', true);
+        setSelectResult(result);
     },
 
     /** If a config was previously selected and now no longer is, unselect any selected results */

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -15,7 +15,6 @@ var ResultView = Backbone.View.extend({
     initialize: function (options) {
         this.config = options.config;
         this.model.on('change:selected', this.updateHighlight, this);
-        setSelectResult(this.model);
     },
 
     template: ['<script type="text/template" id="result-template">',
@@ -153,7 +152,7 @@ var Config = Backbone.View.extend({
      * Called for all events that require re-rendering of the template 
      * after the first render call
      * 
-     * Detatches dropdown inner view in order to preserve events
+     * Detaches dropdown inner view in order to preserve events
      * Resets template, and then reattatches dropdown inner view
      * 
      */

--- a/leaf-ui/rappid-extensions/ConfigInspector.js
+++ b/leaf-ui/rappid-extensions/ConfigInspector.js
@@ -15,6 +15,7 @@ var ResultView = Backbone.View.extend({
     initialize: function (options) {
         this.config = options.config;
         this.model.on('change:selected', this.updateHighlight, this);
+        setSelectResult(this.model);
     },
 
     template: ['<script type="text/template" id="result-template">',


### PR DESCRIPTION
Fixes the issue in which the slider disappeared if the color palette was changed before moving the EVO slider. Fixed by setting the selectResult variable when the new path is simulated.

Fixed #663 